### PR TITLE
update to exclude tests from sonar and removed owner community refere…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,6 @@ pr:
   branches:
     include:
       - main
-  paths:
-    include:
-      - packages
 
 pool:
   vmImage: ubuntu-latest

--- a/build-pipeline/core/function-app-build-stage.yml
+++ b/build-pipeline/core/function-app-build-stage.yml
@@ -116,6 +116,7 @@ stages:
         extraProperties: |
           sonar.javascript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/**/lcov.info
           sonar.scanner.metadataFilePath=$(Agent.TempDirectory)/sonar/$(Build.BuildNumber)/test/report-task.txt
+          sonar.cpd.exclusions=**/*.test.ts
         
     # SonarCloud: Analyze code and code coverage
     - task: SonarCloudAnalyze@3

--- a/docusaurus/decisions/0001-madr-architecture-decisions.md
+++ b/docusaurus/decisions/0001-madr-architecture-decisions.md
@@ -14,7 +14,7 @@ informed:
 
 ## Context and Problem Statement
 
-As the Owner Community project evolves, maintaining architectural consistency becomes crucial. With a Node.js backend and a TypeScript React frontend, documenting and managing architectural decisions pose challenges. We must ensure alignment among team members and community contributors to avoid confusion and inconsistency. Therefore, an efficient framework is needed to document, evaluate, and communicate decisions, fostering transparency and collaboration.
+As the Sharethrift project evolves, maintaining architectural consistency becomes crucial. With a Node.js backend and a TypeScript React frontend, documenting and managing architectural decisions pose challenges. We must ensure alignment among team members and community contributors to avoid confusion and inconsistency. Therefore, an efficient framework is needed to document, evaluate, and communicate decisions, fostering transparency and collaboration.
 
 MADR is a lean template to capture any decisions in a structured way. The template originated from capturing architectural decisions and developed to a template allowing to capture any decisions taken.
 For more information [see](https://adr.github.io/)


### PR DESCRIPTION
…nce in documentation

## Summary by Sourcery

Update architecture decisions document to reference the Sharethrift project instead of Owner Community, and configure SonarCloud to exclude test files from duplication analysis

Build:
- Add sonar.cpd.exclusions setting to skip *.test.ts files in SonarCloud analysis

Documentation:
- Replace 'Owner Community' with 'Sharethrift' in the MADR architecture decisions document