### PR TITLE
very basic routing setup, still needs refinement

### DIFF
--- a/packages/ui-sharethrift/.github/instructions/ui-sharethrift.instructions.md
+++ b/packages/ui-sharethrift/.github/instructions/ui-sharethrift.instructions.md
@@ -5,7 +5,7 @@ applyTo: "./packages/ui-applicant/**/*"
 
 ## Purpose
 
-- The `ui-applicant` package provides the applicant-facing web UI for the CellixJS platform.
+- The `ui-sharethrift` package provides the applicant-facing web UI for the CellixJS platform.
 - Built with React, TypeScript, and Vite, it serves as the entry point for user interactions and application workflows.
 
 ## Architecture & Patterns

--- a/packages/ui-sharethrift/src/App.tsx
+++ b/packages/ui-sharethrift/src/App.tsx
@@ -1,35 +1,17 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+
+import { Navigate, Route, Routes } from 'react-router-dom';
+import SignupRoutes from './components/layouts/signup/Index';
+import HomeRoutes from './components/layouts/home';
+
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <Routes>
+      <Route path="/*" element={<HomeRoutes />} />
+      <Route path="/signup/*" element={<SignupRoutes />} />
+      <Route path="/" element={<Navigate to="/home/listings" replace />} />
+    </Routes>
+  );
 }
 
 export default App

--- a/packages/ui-sharethrift/src/assets/README.md
+++ b/packages/ui-sharethrift/src/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+This folder contains static assets such as images and fonts for the ui-sharethrift application.

--- a/packages/ui-sharethrift/src/components/layouts/home/account/EditSettings.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/account/EditSettings.tsx
@@ -1,0 +1,3 @@
+export default function EditSettings() {
+  return <div>Edit Settings Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/account/Main.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/account/Main.tsx
@@ -1,0 +1,3 @@
+export default function AccountMain() {
+  return <div>Account Main Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/account/Profile.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/account/Profile.tsx
@@ -1,0 +1,3 @@
+export default function Profile() {
+  return <div>Profile Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/account/Settings.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/account/Settings.tsx
@@ -1,0 +1,3 @@
+export default function Settings() {
+  return <div>Settings Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/account/index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/account/index.tsx
@@ -1,0 +1,16 @@
+import { Route, Routes } from 'react-router-dom';
+import EditSettings from './EditSettings';
+import AccountMain from './Main';
+import Profile from './Profile';
+import Settings from './Settings';
+
+export default function AccountRoutes() {
+  return (
+    <Routes>
+      <Route path="" element={<AccountMain />} />
+      <Route path="profile" element={<Profile />} />
+      <Route path="settings" element={<Settings />} />
+      <Route path="settings/edit" element={<EditSettings />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Listings.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Listings.tsx
@@ -1,0 +1,3 @@
+export default function AdminListings() {
+  return <div>Admin Listings Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Main.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Main.tsx
@@ -1,0 +1,3 @@
+export default function AdminDashboardMain() {
+  return <div>Admin Dashboard Main Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Users.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/Users.tsx
@@ -1,0 +1,3 @@
+export default function AdminUsers() {
+  return <div>Admin Users Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/admin-dashboard/index.tsx
@@ -1,0 +1,15 @@
+import { Routes, Route } from "react-router-dom";
+
+import AdminDashboardMain from "./Main";
+import AdminListings from "./Listings";
+import AdminUsers from "./Users";
+
+export default function AdminDashboardRoutes() {
+  return (
+    <Routes>
+      <Route path="" element={<AdminDashboardMain />} />
+      <Route path="listings" element={<AdminListings />} />
+      <Route path="users" element={<AdminUsers />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/components/CreateItem.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/components/CreateItem.tsx
@@ -1,0 +1,3 @@
+export default function CreateItem() {
+  return <div>Create Item Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/components/CreateListing.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/components/CreateListing.tsx
@@ -1,0 +1,3 @@
+export default function CreateListing() {
+  return <div>Create Listing Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/components/CreateReservationRequest.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/components/CreateReservationRequest.tsx
@@ -1,0 +1,3 @@
+export default function CreateReservationRequest() {
+  return <div>Create Reservation Request Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/components/Listings.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/components/Listings.tsx
@@ -1,0 +1,3 @@
+export default function Listings() {
+  return <div>Listings Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/components/ViewListing.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/components/ViewListing.tsx
@@ -1,0 +1,3 @@
+export default function ViewListing() {
+  return <div>View Listing Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/index.tsx
@@ -1,0 +1,21 @@
+
+import { Route, Routes } from "react-router-dom";
+import AccountRoutes from "./account";
+import AdminDashboardRoutes from "./admin-dashboard";
+import MessagesRoutes from "./messages/Index";
+import MyListingsRoutes from "./my-listings/Index";
+import MyReservationsRoutes from "./my-reservations/Index";
+import Listings from "./components/Listings";
+
+export default function HomeRoutes() {
+  return (
+    <Routes>
+      <Route path="home/listings" element={<Listings />} />
+      <Route path="my-listings/*" element={<MyListingsRoutes />} />
+      <Route path="my-reservations/*" element={<MyReservationsRoutes />} />
+      <Route path="messages/*" element={<MessagesRoutes />} />
+      <Route path="account/*" element={<AccountRoutes />} />
+      <Route path="admin-dashboard/*" element={<AdminDashboardRoutes />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/messages/Conversation.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/messages/Conversation.tsx
@@ -1,0 +1,3 @@
+export default function Conversation() {
+  return <div>Conversation Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/messages/Index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/messages/Index.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from "react-router-dom";
+import MessagesMain from "./Main";
+import Conversation from "./Conversation";
+
+export default function MessagesRoutes() {
+  return (
+    <Routes>
+      <Route path="user/:userId" element={<MessagesMain />} />
+      <Route path="user/:userId/conversation/:conversationId" element={<Conversation />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/messages/Main.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/messages/Main.tsx
@@ -1,0 +1,3 @@
+export default function MessagesMain() {
+  return <div>Messages Main Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-listings/EditListing.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-listings/EditListing.tsx
@@ -1,0 +1,3 @@
+export default function EditListing() {
+  return <div>Edit Listing Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-listings/Index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-listings/Index.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from "react-router-dom";
+import MyListingsMain from "./Main";
+import EditListing from "./EditListing";
+
+export default function MyListingsRoutes() {
+  return (
+    <Routes>
+      <Route path="user/:userId" element={<MyListingsMain />} />
+      <Route path="user/:userId/:listingId/edit" element={<EditListing />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-listings/Main.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-listings/Main.tsx
@@ -1,0 +1,3 @@
+export default function MyListingsMain() {
+  return <div>My Listings Main Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-reservations/Index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-reservations/Index.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from "react-router-dom";
+import MyReservationsMain from "./Main";
+import ViewRequest from "./ViewRequest";
+
+export default function MyReservationsRoutes() {
+  return (
+    <Routes>
+      <Route path="user/:userId" element={<MyReservationsMain />} />
+      <Route path="user/:userId/reservation-request/:reservationId/view" element={<ViewRequest />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-reservations/Main.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-reservations/Main.tsx
@@ -1,0 +1,3 @@
+export default function MyReservationsMain() {
+  return <div>My Reservations Main Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/my-reservations/ViewRequest.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/my-reservations/ViewRequest.tsx
@@ -1,0 +1,3 @@
+export default function ViewRequest() {
+  return <div>View Request Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/home/section-layout.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/home/section-layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+
+export default function HomeTabsLayout() {
+  return (
+    <div>
+      {/* Main page layout, tabs, nav, etc. */}
+      <nav>Home Tabs Navigation</nav>
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/login/Login.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/login/Login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>Login Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/AccountSetup.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/AccountSetup.tsx
@@ -1,0 +1,3 @@
+export default function AccountSetup() {
+  return <div>Account Setup Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/Index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/Index.tsx
@@ -1,0 +1,20 @@
+import { Route, Routes } from 'react-router-dom';
+import SignupIndex from './Index';
+import SelectAccountType from './SelectAccountType';
+import Terms from './Terms';
+import AccountSetup from './AccountSetup';
+import ProfileSetup from './ProfileSetup';
+import Payment from './Payment';
+
+export default function SignupRoutes() {
+  return (
+    <Routes>
+      <Route path="/signup" element={<SignupIndex />} />
+      <Route path="/signup/select-account-type" element={<SelectAccountType />} />
+      <Route path="/signup/personal/terms" element={<Terms />} />
+      <Route path="/signup/personal/account-setup" element={<AccountSetup />} />
+      <Route path="/signup/personal/profile-setup" element={<ProfileSetup />} />
+      <Route path="/signup/personal/payment" element={<Payment />} />
+    </Routes>
+  );
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/Index.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/Index.tsx
@@ -9,12 +9,12 @@ import Payment from './Payment';
 export default function SignupRoutes() {
   return (
     <Routes>
-      <Route path="/signup" element={<SignupIndex />} />
-      <Route path="/signup/select-account-type" element={<SelectAccountType />} />
-      <Route path="/signup/personal/terms" element={<Terms />} />
-      <Route path="/signup/personal/account-setup" element={<AccountSetup />} />
-      <Route path="/signup/personal/profile-setup" element={<ProfileSetup />} />
-      <Route path="/signup/personal/payment" element={<Payment />} />
+      <Route path="signup" element={<SignupIndex />} />
+      <Route path="signup/select-account-type" element={<SelectAccountType />} />
+      <Route path="signup/personal/terms" element={<Terms />} />
+      <Route path="signup/personal/account-setup" element={<AccountSetup />} />
+      <Route path="signup/personal/profile-setup" element={<ProfileSetup />} />
+      <Route path="signup/personal/payment" element={<Payment />} />
     </Routes>
   );
 }

--- a/packages/ui-sharethrift/src/components/layouts/signup/Payment.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/Payment.tsx
@@ -1,0 +1,3 @@
+export default function Payment() {
+  return <div>Payment Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/ProfileSetup.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/ProfileSetup.tsx
@@ -1,0 +1,3 @@
+export default function ProfileSetup() {
+  return <div>Profile Setup Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/SelectAccountType.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/SelectAccountType.tsx
@@ -1,0 +1,3 @@
+export default function SelectAccountType() {
+  return <div>Select Account Type Page</div>;
+}

--- a/packages/ui-sharethrift/src/components/layouts/signup/Terms.tsx
+++ b/packages/ui-sharethrift/src/components/layouts/signup/Terms.tsx
@@ -1,0 +1,3 @@
+export default function Terms() {
+  return <div>Terms Page</div>;
+}

--- a/packages/ui-sharethrift/src/logos/README.md
+++ b/packages/ui-sharethrift/src/logos/README.md
@@ -1,0 +1,3 @@
+# Logos
+
+This folder contains logo assets for the ui-sharethrift application.

--- a/packages/ui-sharethrift/src/stories/README.md
+++ b/packages/ui-sharethrift/src/stories/README.md
@@ -1,0 +1,3 @@
+# Stories
+
+This folder contains Storybook stories for the ui-sharethrift application.


### PR DESCRIPTION
## Summary by Sourcery

Set up a basic routing skeleton by replacing the default Vite demo UI with React Router routes, define Home and Signup route groups with nested paths and placeholder page components, and update project instructions and add README stubs for assets, logos, and stories.

New Features:
- Introduce App routing that redirects "/" to "/home/listings" and mounts HomeRoutes and SignupRoutes modules
- Implement HomeRoutes with nested routes for listings, my-listings, my-reservations, messages, account, and admin-dashboard
- Implement SignupRoutes with multi-step signup routes (index, select-account-type, terms, account-setup, profile-setup, payment)
- Scaffold placeholder React components for every defined route under home and signup

Enhancements:
- Remove default Vite+React template content from App.tsx

Documentation:
- Rename .github instructions file to reference ui-sharethrift instead of ui-applicant
- Add README stubs for assets, logos, and stories folders