### PR TITLE
Add react-router-dom to package.json 

### DIFF
--- a/packages/ui-sharethrift/package-lock.json
+++ b/packages/ui-sharethrift/package-lock.json
@@ -12,7 +12,8 @@
         "apollo-link-rest": "^0.9.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-oidc-context": "^3.3.0"
+        "react-oidc-context": "^3.3.0",
+        "react-router-dom": "^7.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2071,6 +2072,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3337,6 +3347,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.1.tgz",
+      "integrity": "sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.1.tgz",
+      "integrity": "sha512-bavdk2BA5r3MYalGKZ01u8PGuDBloQmzpBZVhDLrOOv1N943Wq6dcM9GhB3x8b7AbqPMEezauv4PeGkAJfy7FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rehackt": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
@@ -3455,6 +3503,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/packages/ui-sharethrift/package.json
+++ b/packages/ui-sharethrift/package.json
@@ -15,7 +15,8 @@
     "apollo-link-rest": "^0.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-oidc-context": "^3.3.0"
+    "react-oidc-context": "^3.3.0",
+    "react-router-dom": "^7.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Summary by Sourcery

Add react-router-dom to the ui-sharethrift package dependencies and update the lock file

Enhancements:
- Add react-router-dom@^7.7.1 dependency to packages/ui-sharethrift
- Update package-lock.json to reflect the new dependency