### PR TITLE
removed the ./ from all instruction files

### DIFF
--- a/.github/instructions/ui/components.instructions.md
+++ b/.github/instructions/ui/components.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-*/src/components/**/*"
+applyTo: "packages/ui-*/src/components/**/*"
 ---
 # Copilot Instructions: UI Components
 

--- a/.github/instructions/ui/graphql.instructions.md
+++ b/.github/instructions/ui/graphql.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-applicant/src/components/**/*.graphql"
+applyTo: "packages/ui-applicant/src/components/**/*.graphql"
 ---
 
 ## Copilot Instructions: GraphQL

--- a/.github/instructions/ui/layouts.instructions.md
+++ b/.github/instructions/ui/layouts.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-*/src/components/layouts/**/*"
+applyTo: "packages/ui-*/src/components/layouts/**/*"
 ---
 
 # Copilot Instructions: Layouts
@@ -35,10 +35,10 @@ applyTo: "./packages/ui-*/src/components/layouts/**/*"
 ## Routing & Navigation
 
 - **Each layout must have an `index.tsx` file that defines all top-level routes for that layout.**
-    - These routes are mapped to page components from the `pages/` folder.
-    - The top-level routes in `index.tsx` appear in the sidebar navigation menu.
-    - Each route uses a page component from `pages/` as its `element`.
-    - The sidebar navigation is built from the layout's route configuration and reflects these top-level routes.
+	- These routes are mapped to page components from the `pages/` folder.
+	- The top-level routes in `index.tsx` appear in the sidebar navigation menu.
+	- Each route uses a page component from `pages/` as its `element`.
+	- The sidebar navigation is built from the layout's route configuration and reflects these top-level routes.
 	- The component name in `index.tsx` should match the layout name in PascalCase.
 - **Page components in `pages/` must be mapped in `index.tsx` to be accessible via navigation.**
 

--- a/packages/api-domain/.github/instructions/aggregates.instructions.md
+++ b/packages/api-domain/.github/instructions/aggregates.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.aggregate.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.aggregate.ts"
 ---
 
 # Copilot Instructions: Aggregates

--- a/packages/api-domain/.github/instructions/api-domain.instructions.md
+++ b/packages/api-domain/.github/instructions/api-domain.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/**/*.ts"
+applyTo: "packages/api-domain/**/*.ts"
 ---
 
 # Copilot Instructions: api-domain

--- a/packages/api-domain/.github/instructions/contexts.instructions.md
+++ b/packages/api-domain/.github/instructions/contexts.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.ts"
 ---
 
 # Copilot Instructions: Bounded Contexts
@@ -69,15 +69,15 @@ src/
 - Each bounded context must define its own *DomainPermissions* interface related to interactions with its aggregates.
 ```typescript
 export interface MyContextDomainPermissions {
-	//some aggregate root permissions example
-	canCreateSomeAggregate: boolean;
-	canManageSomeAggregate: boolean;
-	//another aggregate root permissions example
-	canCreateAnotherAggregate: boolean;
+    //some aggregate root permissions example
+    canCreateSomeAggregate: boolean;
+    canManageSomeAggregate: boolean;
+    //another aggregate root permissions example
+    canCreateAnotherAggregate: boolean;
     canModifyAnotherAggregateProfile: boolean;
-	canManageFieldOnAnotherAggregate: boolean;
-	//other permissions
-	isSystemAccount: boolean;
+    canManageFieldOnAnotherAggregate: boolean;
+    //other permissions
+    isSystemAccount: boolean;
 }
 ```
 ### Visas
@@ -86,9 +86,9 @@ export interface MyContextDomainPermissions {
 import type { PassportSeedwork } from '@cellix/domain-seedwork';
 import type { MyContextDomainPermissions } from './my-context.domain-permissions.ts';
 export interface MyContextVisa extends PassportSeedwork.Visa<MyContextDomainPermissions> {
-	determineIf(
-		func: (permissions: Readonly<MyContextDomainPermissions>) => boolean,
-	): boolean;
+    determineIf(
+        func: (permissions: Readonly<MyContextDomainPermissions>) => boolean,
+    ): boolean;
 }
 ```
 ### Passports
@@ -97,7 +97,7 @@ export interface MyContextVisa extends PassportSeedwork.Visa<MyContextDomainPerm
 import type { MyContextVisa } from './community.visa.ts';
 import type { MyContextEntityReference } from './community/community.ts';
 export interface MyContextPassport {
-	forMyAggregate(root: MyAggregateEntityReference): MyContextVisa;
+    forMyAggregate(root: MyAggregateEntityReference): MyContextVisa;
 }
 ```
 

--- a/packages/api-domain/.github/instructions/entities.instructions.md
+++ b/packages/api-domain/.github/instructions/entities.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.entity.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.entity.ts"
 ---
 
 # Copilot Instructions: Entities

--- a/packages/api-domain/.github/instructions/iam.instructions.md
+++ b/packages/api-domain/.github/instructions/iam.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/iam/**/*.ts"
+applyTo: "packages/api-domain/src/domain/iam/**/*.ts"
 ---
 
 # Copilot Instructions: Identity Access and Management

--- a/packages/api-domain/.github/instructions/passports.instructions.md
+++ b/packages/api-domain/.github/instructions/passports.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/iam/**/*.passport.ts"
+applyTo: "packages/api-domain/src/domain/iam/**/*.passport.ts"
 ---
 
 # Copilot Instructions: Passports

--- a/packages/api-domain/.github/instructions/repositories.instructions.md
+++ b/packages/api-domain/.github/instructions/repositories.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.repository.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.repository.ts"
 ---
 
 # Copilot Instructions: Repositories
@@ -36,8 +36,8 @@ export interface MyAggregateRepository<props extends MyAggregateProps>
 	getNewInstance(/* required props for creation */) Promise<MyAggregate<props>>;
 	getById(id: string): Promise<MyAggregate<props>>;
 	// ...other domain-specific methods
-    // getAll(): Promise<MyAggregate<props>[]>;
-    // getBySomeCriteria(criteria: SomeCriteria): Promise<MyAggregate<props>[]>;
+	// getAll(): Promise<MyAggregate<props>[]>;
+	// getBySomeCriteria(criteria: SomeCriteria): Promise<MyAggregate<props>[]>;
 }
 ```
 

--- a/packages/api-domain/.github/instructions/unit-of-works.instructions.md
+++ b/packages/api-domain/.github/instructions/unit-of-works.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.uow.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.uow.ts"
 ---
 
 # Copilot Instructions: Unit of Works

--- a/packages/api-domain/.github/instructions/value-objects.instructions.md
+++ b/packages/api-domain/.github/instructions/value-objects.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-domain/src/domain/contexts/**/*.value-objects.ts"
+applyTo: "packages/api-domain/src/domain/contexts/**/*.value-objects.ts"
 ---
 
 # Copilot Instructions: Value Objects

--- a/packages/api-graphql/.github/instructions/api-graphql.instructions.md
+++ b/packages/api-graphql/.github/instructions/api-graphql.instructions.md
@@ -1,6 +1,6 @@
 ```instructions
 ---
-applyTo: "./packages/api-graphql/**/*.ts"
+applyTo: "packages/api-graphql/**/*.ts"
 ---
 # Copilot Instructions: @ocom/api-graphql
 

--- a/packages/api-persistence/.github/instructions/api-persistence.instructions.md
+++ b/packages/api-persistence/.github/instructions/api-persistence.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api-persistence/**/*.ts"
+applyTo: "packages/api-persistence/**/*.ts"
 ---
 
 # API Persistence Package Development Guide

--- a/packages/api/.github/instructions/api.instructions.md
+++ b/packages/api/.github/instructions/api.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/api/**/*.ts"
+applyTo: "packages/api/**/*.ts"
 ---
 
 # @ocom/api Package Instructions

--- a/packages/cellix-domain-seedwork/.github/instructions/cellix-domain-seedwork.instructions.md
+++ b/packages/cellix-domain-seedwork/.github/instructions/cellix-domain-seedwork.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/cellix-domain-seedwork/**/*.ts"
+applyTo: "packages/cellix-domain-seedwork/**/*.ts"
 ---
 # Copilot Instructions: @cellix/domain-seedwork
 

--- a/packages/cellix-domain-seedwork/.github/instructions/domain-seedwork.instructions.md
+++ b/packages/cellix-domain-seedwork/.github/instructions/domain-seedwork.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/cellix-domain-seedwork/src/domain-seedwork/**/*.ts"
+applyTo: "packages/cellix-domain-seedwork/src/domain-seedwork/**/*.ts"
 ---
 # Copilot Instructions for src/domain-seedwork
 

--- a/packages/cellix-domain-seedwork/.github/instructions/passport-seedwork.instructions.md
+++ b/packages/cellix-domain-seedwork/.github/instructions/passport-seedwork.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/cellix-domain-seedwork/src/passport-seedwork/**/*.ts"
+applyTo: "packages/cellix-domain-seedwork/src/passport-seedwork/**/*.ts"
 ---
 # Copilot Instructions: @cellix-domain-seedwork/src/passport-seedwork
 

--- a/packages/ui-sharethrift/.github/instructions/components.instructions.md
+++ b/packages/ui-sharethrift/.github/instructions/components.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-applicant/src/components/**/*"
+applyTo: "packages/ui-applicant/src/components/**/*"
 ---
 # Copilot Instructions: UI Components
 

--- a/packages/ui-sharethrift/.github/instructions/layouts.instructions.md
+++ b/packages/ui-sharethrift/.github/instructions/layouts.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-applicant/src/components/layouts/**/*"
+applyTo: "packages/ui-applicant/src/components/layouts/**/*"
 ---
 # Copilot Instructions: Layouts
 

--- a/packages/ui-sharethrift/.github/instructions/ui-sharethrift.instructions.md
+++ b/packages/ui-sharethrift/.github/instructions/ui-sharethrift.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "./packages/ui-applicant/**/*"
+applyTo: "packages/ui-applicant/**/*"
 ---
 # Copilot Instructions: ui-applicant
 


### PR DESCRIPTION
## Summary by Sourcery

Remove unnecessary './' prefix from applyTo glob patterns in instruction markdown files and normalize indentation in code examples and lists.

Enhancements:
- Removed leading './' from applyTo paths across all .github/instructions files to ensure consistent glob matching.
- Standardized indentation in code blocks and list items within instruction documents.