### PR TITLE
make sure token from mock server work with authentication flow of backend

### DIFF
--- a/packages/api-application-services/src/index.ts
+++ b/packages/api-application-services/src/index.ts
@@ -1,58 +1,70 @@
 import type { ApiContextSpec } from '@ocom/api-context-spec';
 import { Domain } from '@ocom/api-domain';
 
-// biome-ignore lint/suspicious/noEmptyInterface: <explanation>
-export interface ApplicationServices {
+interface JwtPayload {
+	sub: string;
+	email: string;
 }
 
+// biome-ignore lint/suspicious/noEmptyInterface: <explanation>
+export interface ApplicationServices {}
+
+// biome-ignore lint/complexity/noBannedTypes: <explanation>
 export type PrincipalHints = {
-    memberId: string | undefined;
-    communityId: string | undefined;
+	// memberId: string | undefined;
+	// communityId: string | undefined;
 };
 
 export interface AppServicesHost<S> {
-    forRequest(rawAuthHeader?: string, hints?: PrincipalHints): Promise<S>;
-    // forSystem can be added later without breaking Cellix API:
-    // forSystem?: (opts?: unknown) => Promise<S>;
+	forRequest(rawAuthHeader?: string, hints?: PrincipalHints): Promise<S>;
+	// forSystem can be added later without breaking Cellix API:
+	// forSystem?: (opts?: unknown) => Promise<S>;
 }
 
 export type ApplicationServicesFactory = AppServicesHost<ApplicationServices>;
 
-export const buildApplicationServicesFactory = (infrastructureServicesRegistry: ApiContextSpec): ApplicationServicesFactory => {
-  console.log(infrastructureServicesRegistry)
-    const forRequest = async (rawAuthHeader?: string, hints?: PrincipalHints): Promise<ApplicationServices> => {
-        console.log('rawAuthHeader: ', rawAuthHeader);
-        console.log('hints: ', hints);
-        // const tokenValidationResult = await infrastructureServicesRegistry.tokenValidationService.verifyJwt(rawAuthHeader as string);
-        const tokenValidationResult = { verifiedJwt: { sub: '123'}, openIdConfigKey: 'AccountPortal'};
-        const passport = Domain.PassportFactory.forReadOnly();
-        console.log(passport)
-        if (tokenValidationResult !== null) {
-            const { verifiedJwt, openIdConfigKey } = tokenValidationResult;
-            if (openIdConfigKey === 'AccountPortal') {
-                // when datastore infra service is available, can query for actual documents here
+export const buildApplicationServicesFactory = (
+	infrastructureServicesRegistry: ApiContextSpec,
+): ApplicationServicesFactory => {
+	console.log(infrastructureServicesRegistry);
+	const forRequest = async (
+		rawAuthHeader?: string,
+		hints?: PrincipalHints,
+	): Promise<ApplicationServices> => {
+		console.log('rawAuthHeader: ', rawAuthHeader);
+		console.log('hints: ', hints);
+		const access_token = rawAuthHeader?.replace('Bearer ', '');
+		const tokenValidationResult =
+			await infrastructureServicesRegistry.tokenValidationService.verifyJwt<JwtPayload>(
+				access_token as string,
+			);
+		// const tokenValidationResult = { verifiedJwt: { sub: '123'}, openIdConfigKey: 'AccountPortal'};
+		const passport = Domain.PassportFactory.forReadOnly();
+		console.log(passport);
+		if (tokenValidationResult !== null) {
+			const { verifiedJwt, openIdConfigKey } = tokenValidationResult;
+			if (openIdConfigKey === 'UserPortal') {
+				// when datastore infra service is available, can query for actual documents here
 
-                if (verifiedJwt?.sub) {
-                    // Query for end user document by externalId
-                    await Promise.resolve();
-                }
+				if ((verifiedJwt as { sub: string })?.sub) {
+					// Query for end user document by externalId
+					await Promise.resolve();
+				}
 
-            
-                // const endUser = { id: '123' } as Domain.Contexts.User.EndUser.EndUserEntityReference;
-                // const member = { id: '456', community: { id: '789'}, accounts: [{ user: { id: '123'} }]} as unknown as Domain.Contexts.Community.Member.MemberEntityReference;
-                // const community = { id: '789'} as Domain.Contexts.Community.Community.CommunityEntityReference;
-                // passport = Domain.PassportFactory.forMember(endUser, member, community);
-            } else if (openIdConfigKey === 'StaffPortal') {
-                // const staffUser = {} as Domain.Contexts.User.StaffUser.StaffUserEntityReference;
-                // passport = Domain.PassportFactory.forStaffUser(staffUser);
-            }
-        }
+				// const endUser = { id: '123' } as Domain.Contexts.User.EndUser.EndUserEntityReference;
+				// const member = { id: '456', community: { id: '789'}, accounts: [{ user: { id: '123'} }]} as unknown as Domain.Contexts.Community.Member.MemberEntityReference;
+				// const community = { id: '789'} as Domain.Contexts.Community.Community.CommunityEntityReference;
+				// passport = Domain.PassportFactory.forMember(endUser, member, community);
+			} else if (openIdConfigKey === 'StaffPortal') {
+				// const staffUser = {} as Domain.Contexts.User.StaffUser.StaffUserEntityReference;
+				// passport = Domain.PassportFactory.forStaffUser(staffUser);
+			}
+		}
 
-        return {
-        }
-    }
+		return {};
+	};
 
-    return {
-        forRequest
-    }
-}
+	return {
+		forRequest,
+	};
+};

--- a/packages/api/src/service-config/token-validation/index.ts
+++ b/packages/api/src/service-config/token-validation/index.ts
@@ -1,5 +1,5 @@
 
 export const portalTokens = new Map<string, string>([
-    ['AccountPortal', 'ACCOUNT_PORTAL'],
+    ['UserPortal', 'USER_PORTAL'],
     // ['StaffPortal', 'STAFF_PORTAL'],
 ]);

--- a/packages/service-oauth2-mock-server/index.ts
+++ b/packages/service-oauth2-mock-server/index.ts
@@ -14,6 +14,9 @@ dotenv.config({ path: '.env.local' });
 const app = express();
 app.disable('x-powered-by');
 const port = 4000;
+const allowedRedirectUri =
+	process.env['ALLOWED_REDIRECT_URI'] || 'http://localhost:3000/auth-redirect';
+const aud = allowedRedirectUri;
 // Type for user profile used in token claims
 interface TokenProfile {
 	aud: string;
@@ -134,9 +137,9 @@ async function main() {
 		const email = process.env['Email'] ?? '';
 		const given_name = process.env['Given_Name'] ?? '';
 		const family_name = process.env['Family_Name'] ?? '';
-		const { aud, tid } = req.body;
+		const { tid } = req.body;
 		const profile: TokenProfile = {
-			aud: aud || 'test-client-id',
+			aud: aud,
 			sub: crypto.randomUUID(),
 			iss: `http://localhost:${port}`,
 			email,
@@ -167,10 +170,6 @@ async function main() {
 			claims_supported: ['sub', 'email', 'name'],
 		});
 	});
-
-	const allowedRedirectUri =
-		process.env['ALLOWED_REDIRECT_URI'] ||
-		'http://localhost:3000/auth-redirect';
 
 	app.get('/authorize', (req, res) => {
 		const { redirect_uri, state } = req.query;

--- a/packages/service-token-validation/src/verified-token-service.ts
+++ b/packages/service-token-validation/src/verified-token-service.ts
@@ -49,15 +49,15 @@ export class VerifiedTokenService {
       return; // already running
     }
     //need to run immediately...
-    // (() => {
-    //     this.refreshCollection();
-    // })();
-    // //..as setInterval only runs after the timer runs out
-    // this.timerInstance = setInterval(() => {
-    //   (() => {
-    //     this.refreshCollection();
-    //   })();
-    // }, this.refreshInterval);
+    (() => {
+        this.refreshCollection();
+    })();
+    //..as setInterval only runs after the timer runs out
+    this.timerInstance = setInterval(() => {
+      (() => {
+        this.refreshCollection();
+      })();
+    }, this.refreshInterval);
   }
 
   /**


### PR DESCRIPTION
## Summary by Sourcery

Ensure tokens from the mock OAuth2 server are compatible with the backend authentication flow by aligning portal identifiers, audience values, and using real JWT verification with typed payloads, plus enable immediate JWKS refresh

Enhancements:
- Implement actual JWT verification in buildApplicationServicesFactory by extracting the Bearer token and invoking the infrastructure tokenValidationService.verifyJwt
- Add JwtPayload interface to type the expected JWT claims
- Rename portalTokens map key from 'AccountPortal' to 'UserPortal' to align with the authentication flow
- Centralize allowedRedirectUri and audience configuration in the OAuth2 mock server and apply it to issued tokens
- Trigger immediate JWKS collection refresh on VerifiedTokenService startup