### PR TITLE
update redirect handling to use res.redirect instead of JSON response

### DIFF
--- a/packages/service-oauth2-mock-server/src/index.ts
+++ b/packages/service-oauth2-mock-server/src/index.ts
@@ -180,8 +180,7 @@ async function main() {
 		}
 		const code = 'mock-auth-code';
 		const redirectUrl = `${allowedRedirectUri}?code=${code}${state ? `&state=${state}` : ''}`;
-		// Do not perform redirect based on user-controlled data. Respond with the URL as JSON.
-		res.json({ redirectUrl });
+    res.redirect(redirectUrl);
 		return;
 	});
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Switch from JSON response to res.redirect for redirect handling in the service-oauth2-mock-server