### PR TITLE
initil sendgrid setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"packages/api-graphql",
 				"packages/api-rest",
 				"packages/api",
+				"packages/service-sendgrid",
 				"packages/ui-sharethrift-components"
 			],
 			"dependencies": {
@@ -4881,6 +4882,71 @@
 				"win32"
 			]
 		},
+		"node_modules/@sendgrid/client": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.5.tgz",
+			"integrity": "sha512-Jqt8aAuGIpWGa15ZorTWI46q9gbaIdQFA21HIPQQl60rCjzAko75l3D1z7EyjFrNr4MfQ0StusivWh8Rjh10Cg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sendgrid/helpers": "^8.0.0",
+				"axios": "^1.8.2"
+			},
+			"engines": {
+				"node": ">=12.*"
+			}
+		},
+		"node_modules/@sendgrid/client/node_modules/axios": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+			"integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/@sendgrid/client/node_modules/form-data": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@sendgrid/helpers": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+			"integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+			"license": "MIT",
+			"dependencies": {
+				"deepmerge": "^4.2.2"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/@sendgrid/mail": {
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.5.tgz",
+			"integrity": "sha512-W+YuMnkVs4+HA/bgfto4VHKcPKLc7NiZ50/NH2pzO6UHCCFuq8/GNB98YJlLEr/ESDyzAaDr7lVE7hoBwFTT3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@sendgrid/client": "^8.1.5",
+				"@sendgrid/helpers": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12.*"
+			}
+		},
 		"node_modules/@serenity-js/assertions": {
 			"version": "3.34.0",
 			"resolved": "https://registry.npmjs.org/@serenity-js/assertions/-/assertions-3.34.0.tgz",
@@ -5452,6 +5518,10 @@
 		},
 		"node_modules/@sthrift/service-otel": {
 			"resolved": "packages/service-otel",
+			"link": true
+		},
+		"node_modules/@sthrift/service-sendgrid": {
+			"resolved": "packages/service-sendgrid",
 			"link": true
 		},
 		"node_modules/@sthrift/service-token-validation": {
@@ -8712,6 +8782,15 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
@@ -19353,6 +19432,22 @@
 			},
 			"peerDependencies": {
 				"@cellix/api-services-spec": "^1.0.0"
+			}
+		},
+		"packages/service-sendgrid": {
+			"name": "@sthrift/service-sendgrid",
+			"version": "0.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"@sendgrid/mail": "^8.0.0"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "2.0.0",
+				"typescript": "^5.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=17.0.0",
+				"react-dom": ">=17.0.0"
 			}
 		},
 		"packages/service-token-validation": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"packages/api-graphql",
 		"packages/api-rest",
 		"packages/api",
+        "packages/service-sendgrid",
         "packages/ui-sharethrift-components"
 	],
 	"devDependencies": {

--- a/packages/service-sendgrid/.gitignore
+++ b/packages/service-sendgrid/.gitignore
@@ -1,0 +1,4 @@
+/dist
+/node_modules
+
+tsconfig.tsbuidinfo

--- a/packages/service-sendgrid/package.json
+++ b/packages/service-sendgrid/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@sthrift/service-sendgrid",
+  "version": "0.1.0",
+  "description": "SendGrid email service for ShareThrift portals.",
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc --build",
+    "lint": "biome lint .",
+    "test": "echo 'No tests yet'"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@sendgrid/mail": "^8.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/service-sendgrid/src/get-email-template.ts
+++ b/packages/service-sendgrid/src/get-email-template.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+const baseDir = path.join(process.cwd(), './assets/email-templates');
+
+export const readHtmlFile = (fileName: string): string => {
+  const ext = path.extname(fileName);
+  if (ext && ext !== '.json') {
+    throw new Error('Template must be in HTML format');
+  }
+  if (!ext) {
+    fileName += '.json';
+  }
+  const files = fs.readdirSync(baseDir);
+  const matchedFile = files.find((f) => f.toLowerCase() === fileName.toLowerCase());
+  if (!matchedFile) {
+    throw new Error(`File not found: ${fileName}`);
+  }
+  const filePath = path.join(baseDir, matchedFile);
+  return fs.readFileSync(filePath, 'utf-8');
+};

--- a/packages/service-sendgrid/src/index.ts
+++ b/packages/service-sendgrid/src/index.ts
@@ -1,0 +1,1 @@
+export { default as SendGrid } from './sendgrid.js';

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -17,7 +17,7 @@ export default class SendGrid {
 
   sendEmailWithMagicLink = async (userEmail: string, magicLink: string) => {
     console.log('SendGrid.sendEmail() - email: ', userEmail);
-    let template;
+    let template: { fromEmail: string; subject: string; body: string };
     try {
       template = JSON.parse(readHtmlFile(this.emailTemplateName));
     } catch (err) {
@@ -49,7 +49,7 @@ export default class SendGrid {
       function sanitizeFilename(name: string): string {
         // Replace all invalid filename characters with underscores
         // Invalid chars: / \ : * ? " < > | and also @ for clarity
-        return name.replace(/[@\/\\:\*\?"<>\|]/g, '_');
+        return name.replace(/[@/\\:*?"<>|]/g, '_');
       }
 
       const sanitizedEmail = sanitizeFilename(userEmail);
@@ -71,13 +71,5 @@ export default class SendGrid {
       console.log('Error sending email');
       console.log(error);
     }
-      .then((response) => {
-        console.log('Email sent successfully');
-        console.log(response);
-      })
-      .catch((error) => {
-        console.log('Error sending email');
-        console.log(error);
-      });
   }
 }

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -1,0 +1,58 @@
+import sendgrid from '@sendgrid/mail';
+import { readHtmlFile } from './get-email-template.js';
+import fs from 'fs';
+import path from 'path';
+
+export default class SendGrid {
+  emailTemplateName: string;
+
+  constructor(emailTemplateName: string) {
+    sendgrid.setApiKey(process.env['SENDGRID_API_KEY'] || '');
+    this.emailTemplateName = emailTemplateName;
+  }
+
+  sendEmailWithMagicLink = async (userEmail: string, magicLink: string) => {
+    console.log('SendGrid.sendEmail() - email: ', userEmail);
+    const template = JSON.parse(readHtmlFile(this.emailTemplateName));
+    const templateBodyWithMagicLink = this.replaceMagicLink(template.body, magicLink);
+    const subject = `${template.subject} ${process.env['SENDGRID_MAGICLINK_SUBJECT_SUFFIX']}`;
+    await this.sendEmail(userEmail, template, templateBodyWithMagicLink, subject);
+  };
+
+  private replaceMagicLink = (html: string, link: string): string => {
+    const magicLinkPlaceholder = /\{\{magicLink\}\}/g;
+    return html.replace(magicLinkPlaceholder, link);
+  };
+
+  private async sendEmail(
+    userEmail: string,
+    template: { fromEmail: string; subject: string; body: string },
+    htmlContent: string,
+    subject: string
+  ) {
+    if (process.env["NODE_ENV"] === 'development') {
+      // Save email to disk instead of sending
+      const outDir = path.join(process.cwd(), 'tmp-emails');
+      if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+      const outFile = path.join(outDir, `${userEmail.replace(/@/g, '_at_')}_${Date.now()}.html`);
+      fs.writeFileSync(outFile, htmlContent, 'utf-8');
+      console.log(`Email saved to ${outFile}`);
+      return;
+    }
+    await sendgrid
+      .send({
+        to: userEmail,
+        from: template.fromEmail,
+        subject: subject,
+        html: htmlContent,
+      })
+      .then((response) => {
+        console.log('Email sent successfully');
+        console.log(response);
+      })
+      .catch((error) => {
+        console.log('Error sending email');
+        console.log(error);
+      });
+  }
+}

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -17,7 +17,13 @@ export default class SendGrid {
 
   sendEmailWithMagicLink = async (userEmail: string, magicLink: string) => {
     console.log('SendGrid.sendEmail() - email: ', userEmail);
-    const template = JSON.parse(readHtmlFile(this.emailTemplateName));
+    let template;
+    try {
+      template = JSON.parse(readHtmlFile(this.emailTemplateName));
+    } catch (err) {
+      console.error(`Failed to parse email template JSON for "${this.emailTemplateName}":`, err);
+      throw new Error(`Invalid email template JSON: ${this.emailTemplateName}`);
+    }
     const templateBodyWithMagicLink = this.replaceMagicLink(template.body, magicLink);
     const subject = `${template.subject} ${process.env['SENDGRID_MAGICLINK_SUBJECT_SUFFIX']}`;
     await this.sendEmail(userEmail, template, templateBodyWithMagicLink, subject);

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -7,7 +7,11 @@ export default class SendGrid {
   emailTemplateName: string;
 
   constructor(emailTemplateName: string) {
-    sendgrid.setApiKey(process.env['SENDGRID_API_KEY'] || '');
+    const apiKey = process.env['SENDGRID_API_KEY'];
+    if (!apiKey) {
+      throw new Error('SENDGRID_API_KEY environment variable is missing. Please set it to use SendGrid.');
+    }
+    sendgrid.setApiKey(apiKey);
     this.emailTemplateName = emailTemplateName;
   }
 

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -44,7 +44,16 @@ export default class SendGrid {
       // Save email to disk instead of sending
       const outDir = path.join(process.cwd(), 'tmp-emails');
       if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
-      const outFile = path.join(outDir, `${userEmail.replace(/@/g, '_at_')}_${Date.now()}.html`);
+
+      // Comprehensive filename sanitization
+      function sanitizeFilename(name: string): string {
+        // Replace all invalid filename characters with underscores
+        // Invalid chars: / \ : * ? " < > | and also @ for clarity
+        return name.replace(/[@\/\\:\*\?"<>\|]/g, '_');
+      }
+
+      const sanitizedEmail = sanitizeFilename(userEmail);
+      const outFile = path.join(outDir, `${sanitizedEmail}_${Date.now()}.html`);
       fs.writeFileSync(outFile, htmlContent, 'utf-8');
       console.log(`Email saved to ${outFile}`);
       return;

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -58,13 +58,19 @@ export default class SendGrid {
       console.log(`Email saved to ${outFile}`);
       return;
     }
-    await sendgrid
-      .send({
+    try {
+      const response = await sendgrid.send({
         to: userEmail,
         from: template.fromEmail,
         subject: subject,
         html: htmlContent,
-      })
+      });
+      console.log('Email sent successfully');
+      console.log(response);
+    } catch (error) {
+      console.log('Error sending email');
+      console.log(error);
+    }
       .then((response) => {
         console.log('Email sent successfully');
         console.log(response);

--- a/packages/service-sendgrid/src/sendgrid.ts
+++ b/packages/service-sendgrid/src/sendgrid.ts
@@ -41,18 +41,10 @@ export default class SendGrid {
     subject: string
   ) {
     if (process.env["NODE_ENV"] === 'development') {
-      // Save email to disk instead of sending
       const outDir = path.join(process.cwd(), 'tmp-emails');
       if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
 
-      // Comprehensive filename sanitization
-      function sanitizeFilename(name: string): string {
-        // Replace all invalid filename characters with underscores
-        // Invalid chars: / \ : * ? " < > | and also @ for clarity
-        return name.replace(/[@/\\:*?"<>|]/g, '_');
-      }
-
-      const sanitizedEmail = sanitizeFilename(userEmail);
+      const sanitizedEmail = userEmail.replace(/[@/\\:*?"<>|]/g, '_')
       const outFile = path.join(outDir, `${sanitizedEmail}_${Date.now()}.html`);
       fs.writeFileSync(outFile, htmlContent, 'utf-8');
       console.log(`Email saved to ${outFile}`);

--- a/packages/service-sendgrid/tsconfig.json
+++ b/packages/service-sendgrid/tsconfig.json
@@ -8,8 +8,4 @@
 		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
-	"references": [
-		//needs to match peer dependencies in package.json
-		{ "path": "../cellix-domain-seedwork" }
-	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     { "path": "./packages/service-oauth2-mock-server"},
     { "path": "./packages/service-mongodb-memory-server"},
     { "path": "./packages/ui-sharethrift-components"},
-    { "path": "./packages/ui-sharethrift"}
+    { "path": "./packages/ui-sharethrift"},
+    { "path": "./packages/service-sendgrid" }
   ],
   "lib": ["dom", "esnext"]
 }


### PR DESCRIPTION
## Summary by Sourcery

Initialize and integrate a SendGrid-based email service package into the monorepo

New Features:
- Add a new SendGrid service package with API key handling, template-based email sending, and magic link support

Enhancements:
- Save outgoing emails to disk in development mode with filename sanitization
- Add get-email-template utility for loading JSON email templates from assets

Build:
- Add tsconfig, build, lint, and test scripts for the service-sendgrid package

Chores:
- Add .gitignore to service-sendgrid and update root tsconfig and package.json workspaces to include the new package
- Remove unused project reference to service-mongodb-memory-server from service-mongoose tsconfig