### PR TITLE
Remove variable group reference for Git credentials in Azure Pipelines configuration

### DIFF
--- a/docusaurus/azure-pipelines.yml
+++ b/docusaurus/azure-pipelines.yml
@@ -1,13 +1,10 @@
- trigger:
+trigger:
   branches:
     include:
       - main
   paths:
     include:
       - docusaurus
-
-variables:
-  - group: github-credentials-sharethrift # Reference the variable group containing GH_TOKEN, GH_NAME, GH_EMAIL
 
 pr:
   branches:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove variable group reference for Git credentials in azure-pipelines.yml