### PR TITLE
Update baseUrl in docusaurus.config.js to root path

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'Sharethrift Docs',
   tagline: 'Documentation for Sharethrift',
   url: 'https://simnova.github.io',
-  baseUrl: '/sharethrift/',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change baseUrl in docusaurus.config.js from '/sharethrift/' to '/'