### PR TITLE
Add sharethrift to cSpell words and create CNAME for developers.sharethrift.com

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
         "dataobject",
         "lucaspaganini",
         "maxlength",
-        "seedwork"
+        "seedwork",
+        "sharethrift"
     ],
     "azureFunctions.deploySubpath": "packages/api",
     "azureFunctions.postDeployTask": "npm install (functions)",

--- a/docusaurus/static/CNAME
+++ b/docusaurus/static/CNAME
@@ -1,0 +1,1 @@
+developers.sharethrift.com


### PR DESCRIPTION
## Summary by Sourcery

Allow the custom term 'sharethrift' in spell checks and configure the documentation site for developers.sharethrift.com.

Enhancements:
- Add 'sharethrift' to the cSpell word list in VSCode settings to prevent false spell-check errors.

Deployment:
- Add a CNAME file to Docusaurus static assets to enable the developers.sharethrift.com custom domain.