### PR TITLE
updated build files

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,8 +35,33 @@ jobs:
           node-version: "22"
           cache: "npm"
 
+      - name: Cache node modules
+        id: npm-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install JavaScript dependencies
         run: npm ci
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+        
 
       - name: Install Playwright browsers
         run: |
@@ -44,13 +69,16 @@ jobs:
           npx playwright install --with-deps
         env:
           PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
 
       - name: Install Java SDK (Required for SonarCloud)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
+  
       # - name: Verify required environment variables
       #   run: |
       #     if [ -z "$SONAR_TOKEN" ]; then

--- a/build-pipeline/core/monorepo-build-stage.yml
+++ b/build-pipeline/core/monorepo-build-stage.yml
@@ -322,6 +322,7 @@ stages:
         SONAR_USER_HOME: /home/vsts/work/_temp/.sonar
         JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         SONAR_SCANNER_JAVA_PATH: /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+        SONAR_TOKEN: $(SONAR_TOKEN)
 
     # SonarCloud: Break the build if it doesn't pass the Quality Gate
     - task: sonarcloud-buildbreaker@2


### PR DESCRIPTION
## Summary by Sourcery

Improve CI performance by adding caching for npm modules and Playwright browsers, conditionally skipping installs when caches are valid, upgrade the Java setup action, and expose SONAR_TOKEN in the Azure pipeline

Enhancements:
- Cache npm dependencies and Playwright browsers in the GitHub Actions workflow to speed up CI runs
- Skip installation steps for JavaScript dependencies and Playwright browsers when the cache is hit
- Upgrade setup-java action from v3 to v4

CI:
- Add SONAR_TOKEN environment variable to the Azure monorepo build stage