### PR TITLE
upgrading apollo client to v4

### DIFF
--- a/apps/ui-sharethrift/package.json
+++ b/apps/ui-sharethrift/package.json
@@ -13,12 +13,11 @@
         "build-storybook": "storybook build"
     },
     "dependencies": {
-        "@apollo/client": "^3.14.0",
+        "@apollo/client": "^4.0.7",
         "@sthrift/ui-components": "*",
         "@tailwindcss/vite": "^4.1.11",
         "@twilio/conversations": "^2.6.3",
         "antd": "^5.27.1",
-        "apollo-link-rest": "^0.9.0",
         "clean": "^4.0.2",
         "crypto-hash": "^3.1.0",
         "graphql": "^16.11.0",

--- a/apps/ui-sharethrift/src/components/layouts/home/account/profile/components/profile-view.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/account/profile/components/profile-view.container.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { ProfileView } from '../pages/profile-view.tsx';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import type {
 	CurrentUserQueryData,
 	UserListingsQueryData,

--- a/apps/ui-sharethrift/src/components/layouts/home/account/settings/components/settings-view.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/account/settings/components/settings-view.container.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { message } from 'antd';
 import { SettingsView } from '../pages/settings-view.tsx';
 import type {

--- a/apps/ui-sharethrift/src/components/layouts/home/components/create-listing/create-listing.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/create-listing/create-listing.container.tsx
@@ -1,7 +1,8 @@
 import type React from 'react';
 import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { gql, useMutation } from '@apollo/client';
+import { gql } from '@apollo/client';
+import { useMutation } from "@apollo/client/react";
 import { message } from 'antd';
 // eslint-disable-next-line import/no-absolute-path, @typescript-eslint/ban-ts-comment
 // @ts-ignore - allow raw import string
@@ -45,7 +46,7 @@ export const CreateListingContainer: React.FC<CreateListingContainerProps> = (
 	const [createItemListing, { loading: isCreating }] = useMutation(
 		CREATE_LISTING_MUTATION,
 		{
-			onCompleted: (data) => {
+			onCompleted: (data: any) => {
 				const isDraft = data.createItemListing.state === 'Drafted';
 				message.success(
 					isDraft

--- a/apps/ui-sharethrift/src/components/layouts/home/components/listings-page.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/listings-page.container.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { ListingsPage, type ItemListing } from './listings-page.tsx';
 import {
 	ListingsPageContainerGetListingsDocument,

--- a/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/listing-image-gallery/listing-image-gallery.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/listing-image-gallery/listing-image-gallery.container.tsx
@@ -1,4 +1,5 @@
-import { useQuery, gql } from '@apollo/client';
+import { gql } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { ListingImageGallery } from './listing-image-gallery.tsx';
 // eslint-disable-next-line import/no-absolute-path, @typescript-eslint/ban-ts-comment
 // @ts-ignore - allow raw import string

--- a/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/listing-information/listing-information.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/listing-information/listing-information.container.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useApolloClient } from '@apollo/client';
+import { useApolloClient, useMutation, useQuery } from "@apollo/client/react";
 import { useState } from 'react';
 import { message } from 'antd';
 import { ListingInformation } from './listing-information.tsx';

--- a/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/sharer-information/sharer-information.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/sharer-information/sharer-information.container.tsx
@@ -1,4 +1,5 @@
-import { useQuery, gql } from '@apollo/client';
+import { gql } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { SharerInformation } from './sharer-information.tsx';
 // eslint-disable-next-line import/no-absolute-path, @typescript-eslint/ban-ts-comment
 // @ts-ignore - allow raw import string

--- a/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/view-listing.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/view-listing.container.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 // Import the GraphQL document (Vite raw import if needed)
 // eslint-disable-next-line import/no-absolute-path, @typescript-eslint/ban-ts-comment
 // @ts-ignore - allow raw import string

--- a/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/view-listing.stories.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/components/view-listing/view-listing.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ViewListing } from './view-listing.tsx';
 //import type { ViewListingProps } from "./view-listing";
 import type { ItemListing } from '../../../../../generated.tsx';
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider } from "@apollo/client/testing/react";
 import { gql } from '@apollo/client';
 
 // eslint-disable-next-line import/no-absolute-path, @typescript-eslint/ban-ts-comment

--- a/apps/ui-sharethrift/src/components/layouts/home/messages/components/conversation-box.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/messages/components/conversation-box.container.tsx
@@ -4,7 +4,7 @@ import {
   ConversationBoxContainerConversationDocument,
   type Conversation,
 } from "../../../../../generated.tsx";
-import { useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
 
 interface ConversationBoxContainerProps {
   selectedConversationId: string;

--- a/apps/ui-sharethrift/src/components/layouts/home/messages/components/conversation-list.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/messages/components/conversation-list.container.tsx
@@ -1,5 +1,5 @@
 import { ConversationList } from "./conversation-list.tsx";
-import { useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client/react";
 import {
   HomeConversationListContainerConversationsByUserDocument,
   type Conversation,

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/all-listings-table.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/all-listings-table.container.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { AllListingsTable } from './all-listings-table.tsx';
 import { ComponentQueryLoader } from '@sthrift/ui-components';
 import { HomeAllListingsTableContainerMyListingsAllDocument } from '../../../../../generated.tsx';

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/my-listings-dashboard.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/my-listings-dashboard.container.tsx
@@ -1,5 +1,5 @@
 import { MyListingsDashboard } from './my-listings-dashboard.tsx';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { ComponentQueryLoader } from '@sthrift/ui-components';
 import { HomeAllListingsTableContainerMyListingsAllDocument } from '../../../../../generated.tsx';
 

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useQuery } from '@apollo/client';
+import { useQuery } from "@apollo/client/react";
 import { RequestsTable } from './requests-table.tsx';
 import { ComponentQueryLoader } from '@sthrift/ui-components';
 import { HomeRequestsTableContainerMyListingsRequestsDocument } from '../../../../../generated.tsx';

--- a/apps/ui-sharethrift/src/components/layouts/signup/components/select-account-type.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/signup/components/select-account-type.container.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SelectAccountType } from './select-account-type.tsx';
 import { ComponentQueryLoader } from '@sthrift/ui-components';
-import { useQuery, useMutation } from '@apollo/client';
+import { useMutation, useQuery } from "@apollo/client/react";
 import { useNavigate } from 'react-router-dom';
 import {
 	SignupSelectAccountTypeCurrentPersonalUserAndCreateIfNotExistsDocument,

--- a/apps/ui-sharethrift/src/components/shared/handle-logout.ts
+++ b/apps/ui-sharethrift/src/components/shared/handle-logout.ts
@@ -4,7 +4,7 @@ import type { AuthContextProps } from 'react-oidc-context';
 
 export const HandleLogout = (
 	auth: AuthContextProps,
-	apolloClient: ApolloClient<object>,
+	apolloClient: ApolloClient,
 	post_logout_redirect_uri?: string,
 ) => {
 	// Please do not put await before these 2 functions auth.removeUser() and auth.signoutRedirect() for it will break the logout

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,12 +240,11 @@
 			"name": "@sthrift/ui-sharethrift",
 			"version": "0.0.0",
 			"dependencies": {
-				"@apollo/client": "^3.14.0",
+				"@apollo/client": "^4.0.7",
 				"@sthrift/ui-components": "*",
 				"@tailwindcss/vite": "^4.1.11",
 				"@twilio/conversations": "^2.6.3",
 				"antd": "^5.27.1",
-				"apollo-link-rest": "^0.9.0",
 				"clean": "^4.0.2",
 				"crypto-hash": "^3.1.0",
 				"graphql": "^16.11.0",
@@ -283,6 +282,48 @@
 				"typescript-eslint": "^8.35.1",
 				"vite": "^7.1.2",
 				"vitest": "^3.2.4"
+			}
+		},
+		"apps/ui-sharethrift/node_modules/@apollo/client": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.7.tgz",
+			"integrity": "sha512-hZp/mKtAqM+g6buUnu6Wqtyc33QebvfdY0SE46xWea4lU1CxwI57VORy2N2vA9CoCRgYM4ELNXzr6nNErAdhfg==",
+			"license": "MIT",
+			"workspaces": [
+				"dist",
+				"codegen",
+				"scripts/codemods/ac3-to-ac4"
+			],
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@wry/caches": "^1.0.0",
+				"@wry/equality": "^0.5.6",
+				"@wry/trie": "^0.5.0",
+				"graphql-tag": "^2.12.6",
+				"optimism": "^0.18.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"graphql": "^16.0.0",
+				"graphql-ws": "^5.5.5 || ^6.0.3",
+				"react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"rxjs": "^7.3.0",
+				"subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+			},
+			"peerDependenciesMeta": {
+				"graphql-ws": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"subscriptions-transport-ws": {
+					"optional": true
+				}
 			}
 		},
 		"apps/ui-sharethrift/node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1040,6 +1081,7 @@
 			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.0.tgz",
 			"integrity": "sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@graphql-typed-document-node/core": "^3.1.1",
 				"@wry/caches": "^1.0.0",
@@ -14257,17 +14299,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/apollo-link-rest": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/apollo-link-rest/-/apollo-link-rest-0.9.0.tgz",
-			"integrity": "sha512-kuXjR56Y12w0TZcqwVaONKlipB6g3Ya1dAy4NMCaylPpNXq6tO+qzQFPUyDJC7B0JoJPIFjxPV2rAet4uGM4UQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@apollo/client": ">=3",
-				"graphql": ">=0.11",
-				"qs": ">=6"
 			}
 		},
 		"node_modules/applicationinsights": {
@@ -30434,6 +30465,7 @@
 			"resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
 			"integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "*",
 				"react": "*"
@@ -32851,6 +32883,7 @@
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
 			"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10"
 			}
@@ -33636,6 +33669,7 @@
 			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
 			"integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
 			},
@@ -36396,13 +36430,15 @@
 			"version": "0.8.15",
 			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
 			"integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/zen-observable-ts": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
 			"integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"zen-observable": "0.8.15"
 			}
@@ -36843,12 +36879,14 @@
 			"name": "@sthrift/ui-components",
 			"version": "1.0.0",
 			"dependencies": {
-				"@apollo/client": "^3.13.9",
+				"@apollo/client": "^4.0.7",
 				"antd": "^5.27.1",
+				"graphql": "^16.11.0",
 				"react": "^19.1.1",
 				"react-dom": "^19.1.1",
 				"react-oidc-context": "^3.3.0",
-				"react-router-dom": "^7.8.2"
+				"react-router-dom": "^7.8.2",
+				"rxjs": "^7.8.2"
 			},
 			"devDependencies": {
 				"@cellix/typescript-config": "*",
@@ -36872,6 +36910,48 @@
 				"typescript": "^5.8.3",
 				"vite": "^7.0.4",
 				"vitest": "^3.2.4"
+			}
+		},
+		"packages/sthrift/ui-components/node_modules/@apollo/client": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.7.tgz",
+			"integrity": "sha512-hZp/mKtAqM+g6buUnu6Wqtyc33QebvfdY0SE46xWea4lU1CxwI57VORy2N2vA9CoCRgYM4ELNXzr6nNErAdhfg==",
+			"license": "MIT",
+			"workspaces": [
+				"dist",
+				"codegen",
+				"scripts/codemods/ac3-to-ac4"
+			],
+			"dependencies": {
+				"@graphql-typed-document-node/core": "^3.1.1",
+				"@wry/caches": "^1.0.0",
+				"@wry/equality": "^0.5.6",
+				"@wry/trie": "^0.5.0",
+				"graphql-tag": "^2.12.6",
+				"optimism": "^0.18.0",
+				"tslib": "^2.3.0"
+			},
+			"peerDependencies": {
+				"graphql": "^16.0.0",
+				"graphql-ws": "^5.5.5 || ^6.0.3",
+				"react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+				"rxjs": "^7.3.0",
+				"subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+			},
+			"peerDependenciesMeta": {
+				"graphql-ws": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"subscriptions-transport-ws": {
+					"optional": true
+				}
 			}
 		}
 	}

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation.passport.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation.passport.ts
@@ -1,5 +1,5 @@
-import type { ConversationVisa } from './conversation.visa.ts';
-import type { ConversationEntityReference } from './conversation/conversation.entity.ts';
+import type { ConversationVisa } from './conversation.visa.js';
+import type { ConversationEntityReference } from './conversation/conversation.entity.js';
 
 export interface ConversationPassport {
 	forConversation(root: ConversationEntityReference): ConversationVisa;

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation.visa.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation.visa.ts
@@ -1,4 +1,4 @@
-import type { ConversationDomainPermissions } from './conversation.domain-permissions.ts';
+import type { ConversationDomainPermissions } from './conversation.domain-permissions.js';
 
 export interface ConversationVisa {
 	determineIf(

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.entity.ts
@@ -1,7 +1,7 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import type { MessageEntityReference } from "./message.entity.ts";
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import type { MessageEntityReference } from "./message.entity.js";
 
 export interface ConversationProps extends DomainSeedwork.DomainEntityProps {
 	sharer: Readonly<PersonalUserEntityReference>;

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.repository.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.repository.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Conversation } from './conversation.ts';
-import type { ConversationProps } from './conversation.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/index.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
+import type { Conversation } from './conversation.js';
+import type { ConversationProps } from './conversation.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/index.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
 
 export interface ConversationRepository<props extends ConversationProps>
 	extends DomainSeedwork.Repository<Conversation<props>> {

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.test.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.test.ts
@@ -2,16 +2,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describeFeature, loadFeature } from '@amiceli/vitest-cucumber';
 import { expect, vi } from 'vitest';
-import type { ConversationProps } from './conversation.entity.ts';
-import { Conversation } from './conversation.ts';
+import type { ConversationProps } from './conversation.entity.js';
+import { Conversation } from './conversation.js';
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import { PersonalUser } from '../../user/personal-user/personal-user.ts';
-import type { PersonalUserProps } from '../../user/personal-user/personal-user.entity.ts';
-import { ItemListing } from '../../listing/item/item-listing.ts';
-import type { ItemListingProps } from '../../listing/item/item-listing.entity.ts';
-import { PersonalUserRolePermissions } from '../../role/personal-user-role/personal-user-role-permissions.ts';
-import { PersonalUserRole } from '../../role/personal-user-role/personal-user-role.ts';
+import type { Passport } from '../../passport.js';
+import { PersonalUser } from '../../user/personal-user/personal-user.js';
+import type { PersonalUserProps } from '../../user/personal-user/personal-user.entity.js';
+import { ItemListing } from '../../listing/item/item-listing.js';
+import type { ItemListingProps } from '../../listing/item/item-listing.entity.js';
+import { PersonalUserRolePermissions } from '../../role/personal-user-role/personal-user-role-permissions.js';
+import { PersonalUserRole } from '../../role/personal-user-role/personal-user-role.js';
 
 
 const test = { for: describeFeature };

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.ts
@@ -1,15 +1,15 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { ConversationVisa } from '../conversation.visa.ts';
-import type { Passport } from '../../passport.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
-import { PersonalUser } from '../../user/personal-user/personal-user.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import { ItemListing } from '../../listing/item/item-listing.ts';
+import type { ConversationVisa } from '../conversation.visa.js';
+import type { Passport } from '../../passport.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
+import { PersonalUser } from '../../user/personal-user/personal-user.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import { ItemListing } from '../../listing/item/item-listing.js';
 import type {
 	ConversationEntityReference,
 	ConversationProps,
-} from './conversation.entity.ts';
-import type { MessageEntityReference } from "./message.entity.ts";
+} from './conversation.entity.js';
+import type { MessageEntityReference } from "./message.entity.js";
 
 export class Conversation<props extends ConversationProps>
 	extends DomainSeedwork.AggregateRoot<props, Passport>

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.uow.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.uow.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { ConversationRepository } from './conversation.repository.ts';
-import type { Conversation } from './conversation.ts';
-import type { ConversationProps } from './conversation.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { ConversationRepository } from './conversation.repository.js';
+import type { Conversation } from './conversation.js';
+import type { ConversationProps } from './conversation.entity.js';
 
 export interface ConversationUnitOfWork
 	extends DomainSeedwork.UnitOfWork<

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.value-objects.test.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/conversation.value-objects.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { describeFeature, loadFeature } from '@amiceli/vitest-cucumber';
 import { expect } from 'vitest';
 
-import * as ValueObjects from './conversation.value-objects.ts';
+import * as ValueObjects from './conversation.value-objects.js';
 
 
 const test = { for: describeFeature };

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/index.ts
@@ -1,10 +1,10 @@
-export { Conversation } from './conversation.ts';
-export type {} from './conversation.ts';
+export { Conversation } from './conversation.js';
+export type {} from './conversation.js';
 export type {
 	ConversationProps,
 	ConversationEntityReference,
-} from './conversation.entity.ts';
-export type { ConversationRepository } from './conversation.repository.ts';
-export type { ConversationUnitOfWork } from './conversation.uow.ts';
-export { Message } from './message.entity.ts';
-export type { MessageEntityReference } from './message.entity.ts';
+} from './conversation.entity.js';
+export type { ConversationRepository } from './conversation.repository.js';
+export type { ConversationUnitOfWork } from './conversation.uow.js';
+export { Message } from './message.entity.js';
+export type { MessageEntityReference } from './message.entity.js';

--- a/packages/sthrift/domain/src/domain/contexts/conversation/conversation/message.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/conversation/message.entity.ts
@@ -1,5 +1,5 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type * as ValueObjects from './message.value-objects.ts';
+import type * as ValueObjects from './message.value-objects.js';
 import type { ObjectId } from 'bson';
 
 export interface MessageProps extends DomainSeedwork.DomainEntityProps {

--- a/packages/sthrift/domain/src/domain/contexts/conversation/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/conversation/index.ts
@@ -1,2 +1,2 @@
-export * as Conversation from './conversation/index.ts';
-export type { ConversationPassport } from './conversation.passport.ts';
+export * as Conversation from './conversation/index.js';
+export type { ConversationPassport } from './conversation.passport.js';

--- a/packages/sthrift/domain/src/domain/contexts/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/index.ts
@@ -1,5 +1,5 @@
-export * as Conversation from './conversation/index.ts';
-export * as Listing from './listing/index.ts';
-export * as User from './user/index.ts';
-export * as ReservationRequest from './reservation-request/index.ts';
-export * as Role from './role/index.ts';
+export * as Conversation from './conversation/index.js';
+export * as Listing from './listing/index.js';
+export * as User from './user/index.js';
+export * as ReservationRequest from './reservation-request/index.js';
+export * as Role from './role/index.js';

--- a/packages/sthrift/domain/src/domain/contexts/listing/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/index.ts
@@ -1,1 +1,1 @@
-export * as ItemListing from './item/index.ts';
+export * as ItemListing from './item/index.js';

--- a/packages/sthrift/domain/src/domain/contexts/listing/item/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/item/index.ts
@@ -1,8 +1,8 @@
 export type {
 	ItemListingProps,
 	ItemListingEntityReference,
-} from './item-listing.entity.ts';
-export { ItemListing } from './item-listing.ts';
-export type { ItemListingRepository } from './item-listing.repository.ts';
-export type { ItemListingUnitOfWork } from './item-listing.uow.ts';
-export * as ItemListingValueObjects from './item-listing.value-objects.ts';
+} from './item-listing.entity.js';
+export { ItemListing } from './item-listing.js';
+export type { ItemListingRepository } from './item-listing.repository.js';
+export type { ItemListingUnitOfWork } from './item-listing.uow.js';
+export * as ItemListingValueObjects from './item-listing.value-objects.js';

--- a/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.entity.ts
@@ -1,5 +1,5 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 
 export interface ItemListingProps extends DomainSeedwork.DomainEntityProps {
 	sharer: Readonly<PersonalUserEntityReference>;

--- a/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.repository.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.repository.ts
@@ -1,7 +1,7 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { ItemListing } from './item-listing.ts';
-import type { ItemListingProps } from './item-listing.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import type { ItemListing } from './item-listing.js';
+import type { ItemListingProps } from './item-listing.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 
 export interface ItemListingRepository<props extends ItemListingProps>
 	extends DomainSeedwork.Repository<ItemListing<props>> {

--- a/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.ts
@@ -1,12 +1,12 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { ListingVisa } from '../listing.visa.ts';
-import * as ValueObjects from './item-listing.value-objects.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { ListingVisa } from '../listing.visa.js';
+import * as ValueObjects from './item-listing.value-objects.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 import type {
 	ItemListingEntityReference,
 	ItemListingProps,
-} from './item-listing.entity.ts';
+} from './item-listing.entity.js';
 export class ItemListing<props extends ItemListingProps>
 	extends DomainSeedwork.AggregateRoot<props, Passport>
 	implements ItemListingEntityReference

--- a/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.uow.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/item/item-listing.uow.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { ItemListing } from './item-listing.ts';
-import type { ItemListingRepository } from './item-listing.repository.ts';
-import type { ItemListingProps } from './item-listing.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { ItemListing } from './item-listing.js';
+import type { ItemListingRepository } from './item-listing.repository.js';
+import type { ItemListingProps } from './item-listing.entity.js';
 
 export interface ItemListingUnitOfWork
 	extends DomainSeedwork.UnitOfWork<

--- a/packages/sthrift/domain/src/domain/contexts/listing/listing.passport.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/listing.passport.ts
@@ -1,5 +1,5 @@
-import type { ListingVisa } from './listing.visa.ts';
-import type { ItemListingEntityReference } from './item/item-listing.entity.ts';
+import type { ListingVisa } from './listing.visa.js';
+import type { ItemListingEntityReference } from './item/item-listing.entity.js';
 
 export interface ListingPassport {
 	forItemListing(root: ItemListingEntityReference): ListingVisa;

--- a/packages/sthrift/domain/src/domain/contexts/listing/listing.visa.ts
+++ b/packages/sthrift/domain/src/domain/contexts/listing/listing.visa.ts
@@ -1,5 +1,5 @@
 import type { PassportSeedwork } from '@cellix/domain-seedwork';
-import type { ListingDomainPermissions } from './listing.domain-permissions.ts';
+import type { ListingDomainPermissions } from './listing.domain-permissions.js';
 
 export interface ListingVisa
 	extends PassportSeedwork.Visa<ListingDomainPermissions> {

--- a/packages/sthrift/domain/src/domain/contexts/passport.ts
+++ b/packages/sthrift/domain/src/domain/contexts/passport.ts
@@ -2,13 +2,13 @@ import {
 	GuestPassport,
 	SystemPassport,
 	PersonalUserPassport,
-} from '../iam/index.ts';
-import type { PermissionsSpec } from '../iam/system/system.passport-base.ts';
-import type { Contexts } from '../index.ts';
-import type { ConversationPassport } from './conversation/conversation.passport.ts';
-import type { ListingPassport } from './listing/listing.passport.ts';
-import type { ReservationRequestPassport } from './reservation-request/reservation-request.passport.ts';
-import type { UserPassport } from './user/user.passport.ts';
+} from '../iam/index.js';
+import type { PermissionsSpec } from '../iam/system/system.passport-base.js';
+import type { Contexts } from '../index.js';
+import type { ConversationPassport } from './conversation/conversation.passport.js';
+import type { ListingPassport } from './listing/listing.passport.js';
+import type { ReservationRequestPassport } from './reservation-request/reservation-request.passport.js';
+import type { UserPassport } from './user/user.passport.js';
 
 export interface Passport {
 	get user(): UserPassport;

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/index.ts
@@ -1,2 +1,2 @@
-export * as ReservationRequest from './reservation-request/index.ts';
-export type { ReservationRequestPassport } from './reservation-request.passport.ts';
+export * as ReservationRequest from './reservation-request/index.js';
+export type { ReservationRequestPassport } from './reservation-request.passport.js';

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request.passport.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request.passport.ts
@@ -1,5 +1,5 @@
-import type { ReservationRequestVisa } from './reservation-request.visa.ts';
-import type { ReservationRequestEntityReference } from './reservation-request/reservation-request.entity.ts';
+import type { ReservationRequestVisa } from './reservation-request.visa.js';
+import type { ReservationRequestEntityReference } from './reservation-request/reservation-request.entity.js';
 
 export interface ReservationRequestPassport {
 	forReservationRequest(

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request.visa.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request.visa.ts
@@ -1,5 +1,5 @@
 import type { PassportSeedwork } from '@cellix/domain-seedwork';
-import type { ReservationRequestDomainPermissions } from './reservation-request.domain-permissions.ts';
+import type { ReservationRequestDomainPermissions } from './reservation-request.domain-permissions.js';
 
 export interface ReservationRequestVisa
 	extends PassportSeedwork.Visa<ReservationRequestDomainPermissions> {

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/index.ts
@@ -1,7 +1,7 @@
-export { ReservationRequest } from './reservation-request.ts';
+export { ReservationRequest } from './reservation-request.js';
 export type {
 	ReservationRequestProps,
 	ReservationRequestEntityReference,
-} from './reservation-request.entity.ts';
-export type { ReservationRequestRepository } from './reservation-request.repository.ts';
-export type { ReservationRequestUnitOfWork } from './reservation-request.uow.ts';
+} from './reservation-request.entity.js';
+export type { ReservationRequestRepository } from './reservation-request.repository.js';
+export type { ReservationRequestUnitOfWork } from './reservation-request.uow.js';

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.aggregate.test.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.aggregate.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { ReservationRequest } from './reservation-request.ts';
-import type { ReservationRequestProps } from './reservation-request.entity.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import { ReservationRequest } from './reservation-request.js';
+import type { ReservationRequestProps } from './reservation-request.entity.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 // ...existing code...
 import {
 	ReservationRequestStates,
 	ReservationRequestStateValue,
-} from './reservation-request.value-objects.ts';
-import type { Passport } from '../../passport.ts';
-import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.ts';
-import { PersonalUserRolePermissions } from '../../role/personal-user-role/personal-user-role-permissions.ts';
+} from './reservation-request.value-objects.js';
+import type { Passport } from '../../passport.js';
+import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.js';
+import { PersonalUserRolePermissions } from '../../role/personal-user-role/personal-user-role-permissions.js';
 // Minimal test-only mocks for missing domain value objects
 
 describe('ReservationRequest', () => {

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.entity.ts
@@ -1,6 +1,6 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 
 export interface ReservationRequestProps
 	extends DomainSeedwork.DomainEntityProps {

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.repository.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.repository.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { ReservationRequest } from './reservation-request.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
-import type { ReservationRequestProps } from './reservation-request.entity.ts';
+import type { ReservationRequest } from './reservation-request.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
+import type { ReservationRequestProps } from './reservation-request.entity.js';
 
 export interface ReservationRequestRepository<
 	props extends ReservationRequestProps,

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.ts
@@ -1,14 +1,14 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { ReservationRequestVisa } from '../reservation-request.visa.ts';
-import { ReservationRequestStates } from './reservation-request.value-objects.ts';
-import * as ValueObjects from './reservation-request.value-objects.ts';
-import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.ts';
-import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { ReservationRequestVisa } from '../reservation-request.visa.js';
+import { ReservationRequestStates } from './reservation-request.value-objects.js';
+import * as ValueObjects from './reservation-request.value-objects.js';
+import type { ItemListingEntityReference } from '../../listing/item/item-listing.entity.js';
+import type { PersonalUserEntityReference } from '../../user/personal-user/personal-user.entity.js';
 import type {
 	ReservationRequestEntityReference,
 	ReservationRequestProps,
-} from './reservation-request.entity.ts';
+} from './reservation-request.entity.js';
 
 export class ReservationRequest<props extends ReservationRequestProps>
 	extends DomainSeedwork.AggregateRoot<props, Passport>

--- a/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.uow.ts
+++ b/packages/sthrift/domain/src/domain/contexts/reservation-request/reservation-request/reservation-request.uow.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { ReservationRequest } from './reservation-request.ts';
-import type { ReservationRequestRepository } from './reservation-request.repository.ts';
-import type { ReservationRequestProps } from './reservation-request.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { ReservationRequest } from './reservation-request.js';
+import type { ReservationRequestRepository } from './reservation-request.repository.js';
+import type { ReservationRequestProps } from './reservation-request.entity.js';
 
 export interface ReservationRequestUnitOfWork
 	extends DomainSeedwork.UnitOfWork<

--- a/packages/sthrift/domain/src/domain/contexts/role/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/index.ts
@@ -1,1 +1,1 @@
-export * as PersonalUserRole from './personal-user-role/index.ts';
+export * as PersonalUserRole from './personal-user-role/index.js';

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/index.ts
@@ -1,27 +1,27 @@
-export { PersonalUserRole } from './personal-user-role.ts';
+export { PersonalUserRole } from './personal-user-role.js';
 export type {
 	PersonalUserRoleProps,
 	PersonalUserRoleEntityReference,
-} from './personal-user-role.entity.ts';
+} from './personal-user-role.entity.js';
 export {
 	PersonalUserRoleListingPermissions,
 	type PersonalUserRoleListingPermissionsEntityReference,
 	type PersonalUserRoleListingPermissionsProps,
-} from './personal-user-role-listing-permissions.ts';
+} from './personal-user-role-listing-permissions.js';
 export {
 	PersonalUserRolePermissions,
 	type PersonalUserRolePermissionsEntityReference,
 	type PersonalUserRolePermissionsProps,
-} from './personal-user-role-permissions.ts';
+} from './personal-user-role-permissions.js';
 export {
 	PersonalUserRoleReservationRequestPermissions,
 	type PersonalUserRoleReservationRequestPermissionsEntityReference,
 	type PersonalUserRoleReservationRequestPermissionsProps,
-} from './personal-user-role-reservation-request-permissions.ts';
+} from './personal-user-role-reservation-request-permissions.js';
 export {
 	PersonalUserRoleConversationPermissions,
 	type PersonalUserRoleConversationPermissionsEntityReference,
 	type PersonalUserRoleConversationPermissionsProps,
-} from './personal-user-role-conversation-permissions.ts';
-export type { PersonalUserRoleRepository } from './personal-user-role.repository.ts';
-export type { PersonalUserRoleUnitOfWork } from './personal-user-role.uow.ts';
+} from './personal-user-role-conversation-permissions.js';
+export type { PersonalUserRoleRepository } from './personal-user-role.repository.js';
+export type { PersonalUserRoleUnitOfWork } from './personal-user-role.uow.js';

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role-permissions.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role-permissions.ts
@@ -3,20 +3,20 @@ import { DomainSeedwork } from '@cellix/domain-seedwork';
 import type {
 	PersonalUserRoleListingPermissionsProps,
 	PersonalUserRoleListingPermissionsEntityReference,
-} from './personal-user-role-listing-permissions.ts';
-import { PersonalUserRoleListingPermissions } from './personal-user-role-listing-permissions.ts';
+} from './personal-user-role-listing-permissions.js';
+import { PersonalUserRoleListingPermissions } from './personal-user-role-listing-permissions.js';
 
 import type {
 	PersonalUserRoleConversationPermissionsProps,
 	PersonalUserRoleConversationPermissionsEntityReference,
-} from './personal-user-role-conversation-permissions.ts';
-import { PersonalUserRoleConversationPermissions } from './personal-user-role-conversation-permissions.ts';
+} from './personal-user-role-conversation-permissions.js';
+import { PersonalUserRoleConversationPermissions } from './personal-user-role-conversation-permissions.js';
 
 import type {
 	PersonalUserRoleReservationRequestPermissionsProps,
 	PersonalUserRoleReservationRequestPermissionsEntityReference,
-} from './personal-user-role-reservation-request-permissions.ts';
-import { PersonalUserRoleReservationRequestPermissions } from './personal-user-role-reservation-request-permissions.ts';
+} from './personal-user-role-reservation-request-permissions.js';
+import { PersonalUserRoleReservationRequestPermissions } from './personal-user-role-reservation-request-permissions.js';
 export interface PersonalUserRolePermissionsProps
 	extends DomainSeedwork.ValueObjectProps {
 	readonly listingPermissions: PersonalUserRoleListingPermissionsProps;

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.entity.ts
@@ -2,7 +2,7 @@ import type { DomainSeedwork } from '@cellix/domain-seedwork';
 import type {
 	PersonalUserRolePermissionsEntityReference,
 	PersonalUserRolePermissionsProps,
-} from './personal-user-role-permissions.ts';
+} from './personal-user-role-permissions.js';
 
 export interface PersonalUserRoleProps
 	extends DomainSeedwork.DomainEntityProps {

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.repository.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.repository.ts
@@ -1,6 +1,6 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { PersonalUserRole } from './personal-user-role.ts';
-import type { PersonalUserRoleProps } from './personal-user-role.entity.ts';
+import type { PersonalUserRole } from './personal-user-role.js';
+import type { PersonalUserRoleProps } from './personal-user-role.entity.js';
 
 export interface PersonalUserRoleRepository<props extends PersonalUserRoleProps>
 	extends DomainSeedwork.Repository<PersonalUserRole<props>> {

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.ts
@@ -1,11 +1,11 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import { PersonalUserRolePermissions } from './personal-user-role-permissions.ts';
-import * as ValueObjects from './personal-user-role.value-objects.ts';
+import type { Passport } from '../../passport.js';
+import { PersonalUserRolePermissions } from './personal-user-role-permissions.js';
+import * as ValueObjects from './personal-user-role.value-objects.js';
 import type {
 	PersonalUserRoleEntityReference,
 	PersonalUserRoleProps,
-} from './personal-user-role.entity.ts';
+} from './personal-user-role.entity.js';
 
 export class PersonalUserRole<props extends PersonalUserRoleProps>
 	extends DomainSeedwork.AggregateRoot<props, Passport>

--- a/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.uow.ts
+++ b/packages/sthrift/domain/src/domain/contexts/role/personal-user-role/personal-user-role.uow.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { PersonalUserRoleRepository } from './personal-user-role.repository.ts';
-import type { PersonalUserRole } from './personal-user-role.ts';
-import type { PersonalUserRoleProps } from './personal-user-role.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { PersonalUserRoleRepository } from './personal-user-role.repository.js';
+import type { PersonalUserRole } from './personal-user-role.js';
+import type { PersonalUserRoleProps } from './personal-user-role.entity.js';
 
 export interface PersonalUserRoleUnitOfWork
 	extends DomainSeedwork.UnitOfWork<

--- a/packages/sthrift/domain/src/domain/contexts/user/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/index.ts
@@ -1,1 +1,1 @@
-export * as PersonalUser from './personal-user/index.ts';
+export * as PersonalUser from './personal-user/index.js';

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/index.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/index.ts
@@ -1,11 +1,11 @@
-export { PersonalUser } from './personal-user.ts';
+export { PersonalUser } from './personal-user.js';
 export type {
 	PersonalUserProps,
 	PersonalUserEntityReference,
-} from './personal-user.entity.ts';
-export type { PersonalUserRepository } from './personal-user.repository.ts';
-export type { PersonalUserUnitOfWork } from './personal-user.uow.ts';
-export type { PersonalUserAccountProps } from './personal-user-account.entity.ts';
-export type { PersonalUserProfileProps } from './personal-user-account-profile.entity.ts';
-export type { PersonalUserAccountProfileLocationProps } from './personal-user-account-profile-location.entity.ts';
-export type { PersonalUserAccountProfileBillingProps } from './personal-user-account-profile-billing.entity.ts';
+} from './personal-user.entity.js';
+export type { PersonalUserRepository } from './personal-user.repository.js';
+export type { PersonalUserUnitOfWork } from './personal-user.uow.js';
+export type { PersonalUserAccountProps } from './personal-user-account.entity.js';
+export type { PersonalUserProfileProps } from './personal-user-account-profile.entity.js';
+export type { PersonalUserAccountProfileLocationProps } from './personal-user-account-profile-location.entity.js';
+export type { PersonalUserAccountProfileBillingProps } from './personal-user-account-profile-billing.entity.js';

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile-billing.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile-billing.ts
@@ -1,10 +1,10 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { UserVisa } from '../user.visa.ts';
-import type { PersonalUserAggregateRoot } from './personal-user.ts';
+import type { UserVisa } from '../user.visa.js';
+import type { PersonalUserAggregateRoot } from './personal-user.js';
 import type {
 	PersonalUserAccountProfileBillingEntityReference,
 	PersonalUserAccountProfileBillingProps,
-} from './personal-user-account-profile-billing.entity.ts';
+} from './personal-user-account-profile-billing.entity.js';
 
 export class PersonalUserAccountProfileBilling
 	extends DomainSeedwork.ValueObject<PersonalUserAccountProfileBillingProps>

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile-location.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile-location.ts
@@ -1,10 +1,10 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { UserVisa } from '../user.visa.ts';
-import type { PersonalUserAggregateRoot } from './personal-user.ts';
+import type { UserVisa } from '../user.visa.js';
+import type { PersonalUserAggregateRoot } from './personal-user.js';
 import type {
 	PersonalUserAccountProfileLocationEntityReference,
 	PersonalUserAccountProfileLocationProps,
-} from './personal-user-account-profile-location.entity.ts';
+} from './personal-user-account-profile-location.entity.js';
 
 export class PersonalUserAccountProfileLocation
 	extends DomainSeedwork.ValueObject<PersonalUserAccountProfileLocationProps>

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile.entity.ts
@@ -2,11 +2,11 @@ import type { DomainSeedwork } from '@cellix/domain-seedwork';
 import type {
 	PersonalUserAccountProfileBillingEntityReference,
 	PersonalUserAccountProfileBillingProps,
-} from './personal-user-account-profile-billing.entity.ts';
+} from './personal-user-account-profile-billing.entity.js';
 import type {
 	PersonalUserAccountProfileLocationEntityReference,
 	PersonalUserAccountProfileLocationProps,
-} from './personal-user-account-profile-location.entity.ts';
+} from './personal-user-account-profile-location.entity.js';
 
 export interface PersonalUserProfileProps
 	extends DomainSeedwork.ValueObjectProps {

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account-profile.ts
@@ -1,12 +1,12 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { UserVisa } from '../user.visa.ts';
-import type { PersonalUserAggregateRoot } from './personal-user.ts';
+import type { UserVisa } from '../user.visa.js';
+import type { PersonalUserAggregateRoot } from './personal-user.js';
 import type {
 	PersonalUserProfileEntityReference,
 	PersonalUserProfileProps,
-} from './personal-user-account-profile.entity.ts';
-import { PersonalUserAccountProfileLocation } from './personal-user-account-profile-location.ts';
-import { PersonalUserAccountProfileBilling } from './personal-user-account-profile-billing.ts';
+} from './personal-user-account-profile.entity.js';
+import { PersonalUserAccountProfileLocation } from './personal-user-account-profile-location.js';
+import { PersonalUserAccountProfileBilling } from './personal-user-account-profile-billing.js';
 
 export class PersonalUserProfile
 	extends DomainSeedwork.ValueObject<PersonalUserProfileProps>

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account.entity.ts
@@ -2,7 +2,7 @@ import type { DomainSeedwork } from '@cellix/domain-seedwork';
 import type {
 	PersonalUserProfileEntityReference,
 	PersonalUserProfileProps,
-} from './personal-user-account-profile.entity.ts';
+} from './personal-user-account-profile.entity.js';
 
 export interface PersonalUserAccountProps
 	extends DomainSeedwork.ValueObjectProps {

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user-account.ts
@@ -1,11 +1,11 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { UserVisa } from '../user.visa.ts';
-import type { PersonalUserAggregateRoot } from './personal-user.ts';
-import { PersonalUserProfile } from './personal-user-account-profile.ts';
+import type { UserVisa } from '../user.visa.js';
+import type { PersonalUserAggregateRoot } from './personal-user.js';
+import { PersonalUserProfile } from './personal-user-account-profile.js';
 import type {
 	PersonalUserAccountEntityReference,
 	PersonalUserAccountProps,
-} from './personal-user-account.entity.ts';
+} from './personal-user-account.entity.js';
 
 export class PersonalUserAccount
 	extends DomainSeedwork.ValueObject<PersonalUserAccountProps>

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.entity.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.entity.ts
@@ -2,8 +2,8 @@ import type { DomainSeedwork } from '@cellix/domain-seedwork';
 import type {
 	PersonalUserAccountEntityReference,
 	PersonalUserAccountProps,
-} from './personal-user-account.entity.ts';
-import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.ts';
+} from './personal-user-account.entity.js';
+import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.js';
 
 export interface PersonalUserProps extends DomainSeedwork.DomainEntityProps {
 	userType: string;

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.repository.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.repository.ts
@@ -1,5 +1,5 @@
-import type { PersonalUserProps } from './personal-user.entity.ts';
-import type { PersonalUser } from './personal-user.ts';
+import type { PersonalUserProps } from './personal-user.entity.js';
+import type { PersonalUser } from './personal-user.js';
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
 
 export interface PersonalUserRepository<props extends PersonalUserProps>

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.ts
@@ -1,13 +1,13 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { UserVisa } from '../user.visa.ts';
-import { PersonalUserAccount } from './personal-user-account.ts';
-import { PersonalUserRole } from '../../role/personal-user-role/personal-user-role.ts';
-import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { UserVisa } from '../user.visa.js';
+import { PersonalUserAccount } from './personal-user-account.js';
+import { PersonalUserRole } from '../../role/personal-user-role/personal-user-role.js';
+import type { PersonalUserRoleEntityReference } from '../../role/personal-user-role/personal-user-role.entity.js';
 import type {
 	PersonalUserEntityReference,
 	PersonalUserProps,
-} from './personal-user.entity.ts';
+} from './personal-user.entity.js';
 
 export interface PersonalUserAggregateRoot
 	extends DomainSeedwork.RootEventRegistry {

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.uow.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.uow.ts
@@ -1,8 +1,8 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from '../../passport.ts';
-import type { PersonalUser } from './personal-user.ts';
-import type { PersonalUserRepository } from './personal-user.repository.ts';
-import type { PersonalUserProps } from './personal-user.entity.ts';
+import type { Passport } from '../../passport.js';
+import type { PersonalUser } from './personal-user.js';
+import type { PersonalUserRepository } from './personal-user.repository.js';
+import type { PersonalUserProps } from './personal-user.entity.js';
 
 export interface PersonalUserUnitOfWork
 	extends DomainSeedwork.UnitOfWork<

--- a/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.value-objects.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/personal-user/personal-user.value-objects.ts
@@ -1,6 +1,6 @@
 import { DomainSeedwork } from '@cellix/domain-seedwork';
 import { VOOptional } from '@lucaspaganini/value-objects';
-import { Email as EmailBase } from '../../value-objects.ts';
+import { Email as EmailBase } from '../../value-objects.js';
 /**
  * Value objects for User aggregate validation and data integrity.
  */

--- a/packages/sthrift/domain/src/domain/contexts/user/user.passport.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/user.passport.ts
@@ -1,5 +1,5 @@
-import type { UserVisa } from './user.visa.ts';
-import type { PersonalUserEntityReference } from './personal-user/personal-user.entity.ts';
+import type { UserVisa } from './user.visa.js';
+import type { PersonalUserEntityReference } from './personal-user/personal-user.entity.js';
 
 export interface UserPassport {
 	forPersonalUser(root: PersonalUserEntityReference): UserVisa;

--- a/packages/sthrift/domain/src/domain/contexts/user/user.visa.ts
+++ b/packages/sthrift/domain/src/domain/contexts/user/user.visa.ts
@@ -1,5 +1,5 @@
 import type { PassportSeedwork } from '@cellix/domain-seedwork';
-import type { UserDomainPermissions } from './user.domain-permissions.ts';
+import type { UserDomainPermissions } from './user.domain-permissions.js';
 
 export interface UserVisa extends PassportSeedwork.Visa<UserDomainPermissions> {
 	determineIf(

--- a/packages/sthrift/domain/src/domain/contexts/value-objects.test.ts
+++ b/packages/sthrift/domain/src/domain/contexts/value-objects.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describeFeature, loadFeature } from '@amiceli/vitest-cucumber';
 import { expect } from 'vitest';
-import * as ValueObjects from './value-objects.ts';
+import * as ValueObjects from './value-objects.js';
 
 
 const test = { for: describeFeature };

--- a/packages/sthrift/domain/src/domain/domain-execution-context.ts
+++ b/packages/sthrift/domain/src/domain/domain-execution-context.ts
@@ -1,5 +1,5 @@
 import type { DomainSeedwork } from '@cellix/domain-seedwork';
-import type { Passport } from './contexts/passport.ts';
+import type { Passport } from './contexts/passport.js';
 
 export interface DomainExecutionContext
 	extends DomainSeedwork.BaseDomainExecutionContext {

--- a/packages/sthrift/domain/src/domain/events/index.ts
+++ b/packages/sthrift/domain/src/domain/events/index.ts
@@ -1,1 +1,1 @@
-export { EventBusInstance } from './event-bus.ts';
+export { EventBusInstance } from './event-bus.js';

--- a/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.conversation.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.conversation.passport.ts
@@ -1,7 +1,7 @@
-import type { ConversationEntityReference } from '../../../contexts/conversation/conversation/index.ts';
-import type { ConversationPassport } from './../../../contexts/conversation/conversation.passport.ts';
-import type { ConversationVisa } from '../../../contexts/conversation/conversation.visa.ts';
-import { GuestPassportBase } from '../guest.passport-base.ts';
+import type { ConversationEntityReference } from '../../../contexts/conversation/conversation/index.js';
+import type { ConversationPassport } from './../../../contexts/conversation/conversation.passport.js';
+import type { ConversationVisa } from '../../../contexts/conversation/conversation.visa.js';
+import { GuestPassportBase } from '../guest.passport-base.js';
 
 export class GuestConversationPassport
 	extends GuestPassportBase

--- a/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.listing.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.listing.passport.ts
@@ -1,7 +1,7 @@
-import type { ItemListingEntityReference } from '../../../contexts/listing/item/index.ts';
-import type { ListingPassport } from './../../../contexts/listing/listing.passport.ts';
-import type { ListingVisa } from '../../../contexts/listing/listing.visa.ts';
-import { GuestPassportBase } from '../guest.passport-base.ts';
+import type { ItemListingEntityReference } from '../../../contexts/listing/item/index.js';
+import type { ListingPassport } from './../../../contexts/listing/listing.passport.js';
+import type { ListingVisa } from '../../../contexts/listing/listing.visa.js';
+import { GuestPassportBase } from '../guest.passport-base.js';
 
 export class GuestListingPassport
 	extends GuestPassportBase

--- a/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.reservation-request.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.reservation-request.passport.ts
@@ -1,7 +1,7 @@
-import type { ReservationRequestEntityReference } from '../../../contexts/reservation-request/reservation-request/index.ts';
-import type { ReservationRequestPassport } from './../../../contexts/reservation-request/reservation-request.passport.ts';
-import type { ReservationRequestVisa } from '../../../contexts/reservation-request/reservation-request.visa.ts';
-import { GuestPassportBase } from '../guest.passport-base.ts';
+import type { ReservationRequestEntityReference } from '../../../contexts/reservation-request/reservation-request/index.js';
+import type { ReservationRequestPassport } from './../../../contexts/reservation-request/reservation-request.passport.js';
+import type { ReservationRequestVisa } from '../../../contexts/reservation-request/reservation-request.visa.js';
+import { GuestPassportBase } from '../guest.passport-base.js';
 
 export class GuestReservationRequestPassport
 	extends GuestPassportBase

--- a/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.user.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/guest/contexts/guest.user.passport.ts
@@ -1,7 +1,7 @@
-import type { PersonalUserEntityReference } from '../../../contexts/user/personal-user/index.ts';
-import type { UserPassport } from '../../../contexts/user/user.passport.ts';
-import type { UserVisa } from '../../../contexts/user/user.visa.ts';
-import { GuestPassportBase } from '../guest.passport-base.ts';
+import type { PersonalUserEntityReference } from '../../../contexts/user/personal-user/index.js';
+import type { UserPassport } from '../../../contexts/user/user.passport.js';
+import type { UserVisa } from '../../../contexts/user/user.visa.js';
+import { GuestPassportBase } from '../guest.passport-base.js';
 
 export class GuestUserPassport
 	extends GuestPassportBase

--- a/packages/sthrift/domain/src/domain/iam/guest/guest.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/guest/guest.passport.ts
@@ -1,13 +1,13 @@
-import type { ListingPassport } from '../../contexts/listing/listing.passport.ts';
-import type { ReservationRequestPassport } from '../../contexts/reservation-request/reservation-request.passport.ts';
-import type { Passport } from '../../contexts/passport.ts';
-import type { UserPassport } from '../../contexts/user/user.passport.ts';
-import { GuestUserPassport } from './contexts/guest.user.passport.ts';
-import { GuestListingPassport } from './contexts/guest.listing.passport.ts';
-import { GuestConversationPassport } from './contexts/guest.conversation.passport.ts';
-import type { ConversationPassport } from '../../contexts/conversation/conversation.passport.ts';
-import { GuestPassportBase } from './guest.passport-base.ts';
-import { GuestReservationRequestPassport } from './contexts/guest.reservation-request.passport.ts';
+import type { ListingPassport } from '../../contexts/listing/listing.passport.js';
+import type { ReservationRequestPassport } from '../../contexts/reservation-request/reservation-request.passport.js';
+import type { Passport } from '../../contexts/passport.js';
+import type { UserPassport } from '../../contexts/user/user.passport.js';
+import { GuestUserPassport } from './contexts/guest.user.passport.js';
+import { GuestListingPassport } from './contexts/guest.listing.passport.js';
+import { GuestConversationPassport } from './contexts/guest.conversation.passport.js';
+import type { ConversationPassport } from '../../contexts/conversation/conversation.passport.js';
+import { GuestPassportBase } from './guest.passport-base.js';
+import { GuestReservationRequestPassport } from './contexts/guest.reservation-request.passport.js';
 
 export class GuestPassport extends GuestPassportBase implements Passport {
 	private _userPassport: UserPassport | undefined;

--- a/packages/sthrift/domain/src/domain/iam/index.ts
+++ b/packages/sthrift/domain/src/domain/iam/index.ts
@@ -1,3 +1,3 @@
-export { SystemPassport } from './system/system.passport.ts';
-export { GuestPassport } from './guest/guest.passport.ts';
-export { PersonalUserPassport } from './user/personal-user.passport.ts';
+export { SystemPassport } from './system/system.passport.js';
+export { GuestPassport } from './guest/guest.passport.js';
+export { PersonalUserPassport } from './user/personal-user.passport.js';

--- a/packages/sthrift/domain/src/domain/iam/system/contexts/system.conversation.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/contexts/system.conversation.passport.ts
@@ -1,8 +1,8 @@
-import type { ConversationEntityReference } from '../../../contexts/conversation/conversation/conversation.entity.ts';
-import type { ConversationPassport } from '../../../contexts/conversation/conversation.passport.ts';
-import { SystemPassportBase } from '../system.passport-base.ts';
-import type { ConversationVisa } from '../../../contexts/conversation/conversation.visa.ts';
-import type { ConversationDomainPermissions } from '../../../contexts/conversation/conversation.domain-permissions.ts';
+import type { ConversationEntityReference } from '../../../contexts/conversation/conversation/conversation.entity.js';
+import type { ConversationPassport } from '../../../contexts/conversation/conversation.passport.js';
+import { SystemPassportBase } from '../system.passport-base.js';
+import type { ConversationVisa } from '../../../contexts/conversation/conversation.visa.js';
+import type { ConversationDomainPermissions } from '../../../contexts/conversation/conversation.domain-permissions.js';
 export class SystemConversationPassport
 	extends SystemPassportBase
 	implements ConversationPassport

--- a/packages/sthrift/domain/src/domain/iam/system/contexts/system.listing.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/contexts/system.listing.passport.ts
@@ -1,8 +1,8 @@
-import type { ItemListingEntityReference } from '../../../contexts/listing/item/item-listing.entity.ts';
-import type { ListingPassport } from '../../../contexts/listing/listing.passport.ts';
-import { SystemPassportBase } from '../system.passport-base.ts';
-import type { ListingVisa } from '../../../contexts/listing/listing.visa.ts';
-import type { ListingDomainPermissions } from '../../../contexts/listing/listing.domain-permissions.ts';
+import type { ItemListingEntityReference } from '../../../contexts/listing/item/item-listing.entity.js';
+import type { ListingPassport } from '../../../contexts/listing/listing.passport.js';
+import { SystemPassportBase } from '../system.passport-base.js';
+import type { ListingVisa } from '../../../contexts/listing/listing.visa.js';
+import type { ListingDomainPermissions } from '../../../contexts/listing/listing.domain-permissions.js';
 
 export class SystemListingPassport
 	extends SystemPassportBase

--- a/packages/sthrift/domain/src/domain/iam/system/contexts/system.reservation-request.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/contexts/system.reservation-request.ts
@@ -1,8 +1,8 @@
-import type { ReservationRequestEntityReference } from '../../../contexts/reservation-request/reservation-request/reservation-request.entity.ts';
-import type { ReservationRequestPassport } from '../../../contexts/reservation-request/reservation-request.passport.ts';
-import { SystemPassportBase } from '../system.passport-base.ts';
-import type { ReservationRequestVisa } from '../../../contexts/reservation-request/reservation-request.visa.ts';
-import type { ReservationRequestDomainPermissions } from '../../../contexts/reservation-request/reservation-request.domain-permissions.ts';
+import type { ReservationRequestEntityReference } from '../../../contexts/reservation-request/reservation-request/reservation-request.entity.js';
+import type { ReservationRequestPassport } from '../../../contexts/reservation-request/reservation-request.passport.js';
+import { SystemPassportBase } from '../system.passport-base.js';
+import type { ReservationRequestVisa } from '../../../contexts/reservation-request/reservation-request.visa.js';
+import type { ReservationRequestDomainPermissions } from '../../../contexts/reservation-request/reservation-request.domain-permissions.js';
 
 export class SystemReservationRequestPassport
 	extends SystemPassportBase

--- a/packages/sthrift/domain/src/domain/iam/system/contexts/system.user.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/contexts/system.user.passport.ts
@@ -1,8 +1,8 @@
-import type { PersonalUserEntityReference } from '../../../contexts/user/personal-user/index.ts';
-import type { UserPassport } from '../../../contexts/user/user.passport.ts';
-import type { UserVisa } from '../../../contexts/user/user.visa.ts';
-import { SystemPassportBase } from '../system.passport-base.ts';
-import type { UserDomainPermissions } from '../../../contexts/user/user.domain-permissions.ts';
+import type { PersonalUserEntityReference } from '../../../contexts/user/personal-user/index.js';
+import type { UserPassport } from '../../../contexts/user/user.passport.js';
+import type { UserVisa } from '../../../contexts/user/user.visa.js';
+import { SystemPassportBase } from '../system.passport-base.js';
+import type { UserDomainPermissions } from '../../../contexts/user/user.domain-permissions.js';
 
 export class SystemUserPassport
 	extends SystemPassportBase

--- a/packages/sthrift/domain/src/domain/iam/system/system.passport-base.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/system.passport-base.ts
@@ -1,6 +1,6 @@
-import type { UserDomainPermissions } from '../../contexts/user/user.domain-permissions.ts';
-import type { ListingDomainPermissions } from '../../contexts/listing/listing.domain-permissions.ts';
-import type { ConversationDomainPermissions } from '../../contexts/conversation/conversation.domain-permissions.ts';
+import type { UserDomainPermissions } from '../../contexts/user/user.domain-permissions.js';
+import type { ListingDomainPermissions } from '../../contexts/listing/listing.domain-permissions.js';
+import type { ConversationDomainPermissions } from '../../contexts/conversation/conversation.domain-permissions.js';
 
 export type PermissionsSpec =
 	| UserDomainPermissions

--- a/packages/sthrift/domain/src/domain/iam/system/system.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/system/system.passport.ts
@@ -1,13 +1,13 @@
-import type { Passport } from '../../contexts/passport.ts';
-import type { UserPassport } from '../../contexts/user/user.passport.ts';
-import type { ListingPassport } from '../../contexts/listing/listing.passport.ts';
-import type { ConversationPassport } from '../../contexts/conversation/conversation.passport.ts';
-import type { ReservationRequestPassport } from '../../contexts/reservation-request/reservation-request.passport.ts';
-import { SystemUserPassport } from './contexts/system.user.passport.ts';
-import { SystemListingPassport } from './contexts/system.listing.passport.ts';
-import { SystemConversationPassport } from './contexts/system.conversation.passport.ts'; // Ensure this file exists and is named correctly
-import { SystemReservationRequestPassport } from './contexts/system.reservation-request.ts';
-import { SystemPassportBase } from './system.passport-base.ts';
+import type { Passport } from '../../contexts/passport.js';
+import type { UserPassport } from '../../contexts/user/user.passport.js';
+import type { ListingPassport } from '../../contexts/listing/listing.passport.js';
+import type { ConversationPassport } from '../../contexts/conversation/conversation.passport.js';
+import type { ReservationRequestPassport } from '../../contexts/reservation-request/reservation-request.passport.js';
+import { SystemUserPassport } from './contexts/system.user.passport.js';
+import { SystemListingPassport } from './contexts/system.listing.passport.js';
+import { SystemConversationPassport } from './contexts/system.conversation.passport.js'; // Ensure this file exists and is named correctly
+import { SystemReservationRequestPassport } from './contexts/system.reservation-request.js';
+import { SystemPassportBase } from './system.passport-base.js';
 
 export class SystemPassport extends SystemPassportBase implements Passport {
 	private _userPassport: UserPassport | undefined;

--- a/packages/sthrift/domain/src/domain/iam/user/personal-user.passport-base.ts
+++ b/packages/sthrift/domain/src/domain/iam/user/personal-user.passport-base.ts
@@ -1,4 +1,4 @@
-import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.ts';
+import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.js';
 export class PersonalUserPassportBase {
 	protected readonly _user: PersonalUserEntityReference;
 	constructor(user: PersonalUserEntityReference) {

--- a/packages/sthrift/domain/src/domain/iam/user/personal-user.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/user/personal-user.passport.ts
@@ -1,7 +1,7 @@
-import { PersonalUserPassportBase } from './personal-user.passport-base.ts';
-import type { Passport } from '../../contexts/passport.ts';
-import type { UserPassport } from '../../contexts/user/user.passport.ts';
-import { PersonalUserUserPassport } from './personal-user.user.passport.ts';
+import { PersonalUserPassportBase } from './personal-user.passport-base.js';
+import type { Passport } from '../../contexts/passport.js';
+import type { UserPassport } from '../../contexts/user/user.passport.js';
+import { PersonalUserUserPassport } from './personal-user.user.passport.js';
 export class PersonalUserPassport
 	extends PersonalUserPassportBase
 	implements Passport

--- a/packages/sthrift/domain/src/domain/iam/user/personal-user.user.passport.ts
+++ b/packages/sthrift/domain/src/domain/iam/user/personal-user.user.passport.ts
@@ -1,8 +1,8 @@
-import { PersonalUserUserVisa } from './personal-user.user.visa.ts';
-import { PersonalUserPassportBase } from './personal-user.passport-base.ts';
-import type { UserPassport } from '../../contexts/user/user.passport.ts';
-import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.ts';
-import type { UserVisa } from '../../contexts/user/user.visa.ts';
+import { PersonalUserUserVisa } from './personal-user.user.visa.js';
+import { PersonalUserPassportBase } from './personal-user.passport-base.js';
+import type { UserPassport } from '../../contexts/user/user.passport.js';
+import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.js';
+import type { UserVisa } from '../../contexts/user/user.visa.js';
 
 export class PersonalUserUserPassport
 	extends PersonalUserPassportBase

--- a/packages/sthrift/domain/src/domain/iam/user/personal-user.user.visa.ts
+++ b/packages/sthrift/domain/src/domain/iam/user/personal-user.user.visa.ts
@@ -1,6 +1,6 @@
-import type { UserDomainPermissions } from '../../contexts/user/user.domain-permissions.ts';
-import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.ts';
-import type { UserVisa } from '../../contexts/user/user.visa.ts';
+import type { UserDomainPermissions } from '../../contexts/user/user.domain-permissions.js';
+import type { PersonalUserEntityReference } from '../../contexts/user/personal-user/personal-user.entity.js';
+import type { UserVisa } from '../../contexts/user/user.visa.js';
 export class PersonalUserUserVisa<root extends PersonalUserEntityReference>
 	implements UserVisa
 {

--- a/packages/sthrift/domain/src/domain/index.ts
+++ b/packages/sthrift/domain/src/domain/index.ts
@@ -1,4 +1,4 @@
 
-export * as Contexts from './contexts/index.ts';
-export type { Services } from './services/index.ts';
-export { type Passport, PassportFactory } from './contexts/passport.ts';
+export * as Contexts from './contexts/index.js';
+export type { Services } from './services/index.js';
+export { type Passport, PassportFactory } from './contexts/passport.js';

--- a/packages/sthrift/domain/src/domain/services/index.ts
+++ b/packages/sthrift/domain/src/domain/services/index.ts
@@ -1,4 +1,4 @@
-import type { BlobStorage } from './blob-storage.ts';
+import type { BlobStorage } from './blob-storage.js';
 
 export interface Services {
     BlobStorage: BlobStorage;

--- a/packages/sthrift/domain/src/index.ts
+++ b/packages/sthrift/domain/src/index.ts
@@ -1,6 +1,6 @@
-export * from './domain/contexts/index.ts';
-import type { Contexts } from './domain/index.ts';
-export * as Domain from './domain/index.ts';
+export * from './domain/contexts/index.js';
+import type { Contexts } from './domain/index.js';
+export * as Domain from './domain/index.js';
 
 export interface DomainDataSource {
 	User: {

--- a/packages/sthrift/ui-components/package.json
+++ b/packages/sthrift/ui-components/package.json
@@ -32,18 +32,18 @@
 		"build-storybook": "storybook build"
 	},
 	"dependencies": {
-		"@apollo/client": "^3.13.9",
+		"@apollo/client": "^4.0.7",
 		"antd": "^5.27.1",
+		"graphql": "^16.11.0",
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
 		"react-oidc-context": "^3.3.0",
-		"react-router-dom": "^7.8.2"
+		"react-router-dom": "^7.8.2",
+		"rxjs": "^7.8.2"
 	},
 	"devDependencies": {
 		"@cellix/typescript-config": "*",
 		"@cellix/vitest-config": "*",
-		"typescript": "^5.8.3",
-		"rimraf": "^6.0.1",
 		"@chromatic-com/storybook": "^4.1.1",
 		"@storybook/addon-a11y": "^9.1.3",
 		"@storybook/addon-docs": "^9.1.3",
@@ -57,8 +57,10 @@
 		"jsdom": "^26.1.0",
 		"markdown-to-jsx": "^7.4.6",
 		"playwright": "^1.55.0",
+		"rimraf": "^6.0.1",
 		"storybook": "^9.1.3",
 		"storybook-addon-apollo-client": "^9.0.0",
+		"typescript": "^5.8.3",
 		"vite": "^7.0.4",
 		"vitest": "^3.2.4"
 	}

--- a/packages/sthrift/ui-components/src/molecules/message-sharer-button.tsx
+++ b/packages/sthrift/ui-components/src/molecules/message-sharer-button.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useMutation } from '@apollo/client';
+import { useMutation } from "@apollo/client/react";
 import { gql } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
 
@@ -15,6 +15,17 @@ const CREATE_CONVERSATION = gql`
     }
   }
 `;
+
+interface CreateConversationData {
+	createConversation: {
+		id: string;
+		twilioConversationSid: string;
+		listingId: string;
+		participants: string[];
+		createdAt: string;
+		updatedAt: string;
+	};
+}
 
 interface MessageSharerButtonProps {
 	listingId: string;
@@ -33,7 +44,7 @@ export function MessageSharerButton({
 	// TODO: Get actual user ID from authentication context
 	const currentUserId = 'user123'; // Placeholder
 
-	const [createConversation] = useMutation(CREATE_CONVERSATION, {
+	const [createConversation] = useMutation<CreateConversationData>(CREATE_CONVERSATION, {
 		onCompleted: (data) => {
 			// Navigate to the messages page with the conversation
 			navigate(`/messages/user/${currentUserId}`, {


### PR DESCRIPTION
Apollo Client v3 → v4 Migration - Complete Change Summary

1. Package Installation (Following Official Migration Guide)
2. Ran Official Apollo Codemod (Automated Migration Tool)
3. Cleaned Up Codemod Output
4. Fixed Domain Package Import Extensions (ESM Module Resolution)
    - Bulk fix across entire domain package:  Changed .ts → .js in imports
    - This fixed TypeScript module resolution errors in .d.ts files (TS2306 errors)

Fixes #211

## Summary by Sourcery

Migrate to Apollo Client v4 and ESM module resolution by upgrading dependencies, applying codemods, and updating import paths and Apollo link implementations

Bug Fixes:
- Fix TypeScript ESM resolution errors by changing all domain package import extensions from .ts to .js

Enhancements:
- Upgrade @apollo/client to v4 and replace RestLink with HttpLink and updated ApolloLink composition
- Add generic types to useMutation and adjust useQuery import source

Build:
- Bump Apollo Client and related dependencies (graphql, rxjs) and update package.json entries

Tests:
- Adjust test import paths to use .js extensions

Chores:
- Run official Apollo codemod and clean up generated output