### PR TITLE
feat: enforce unique constraint on account email in PersonalUser schema

### DIFF
--- a/packages/sthrift/data-sources-mongoose-models/src/models/user/personal-user.model.ts
+++ b/packages/sthrift/data-sources-mongoose-models/src/models/user/personal-user.model.ts
@@ -116,7 +116,6 @@ export const PersonalUserAccountType: SchemaDefinition<PersonalUserAccount> = {
 		match: Patterns.EMAIL_PATTERN,
 		maxlength: 254,
 		required: true,
-		unique: true,
 	},
 	username: {
 		type: String,
@@ -164,7 +163,7 @@ const PersonalUserSchema = new Schema<
 		schemaVersion: { type: String, required: true, default: '1.0.0' },
 	},
 	userOptions,
-).index({ 'account.email': 1 }, { sparse: true });
+).index({ 'account.email': 1 }, { sparse: true, unique: true });
 
 export const PersonalUserModelName: string = 'personal-users'; //TODO: This should be in singular form
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce a unique constraint on the account.email field in the PersonalUser schema by adding a sparse unique index and removing the inline unique property

Enhancements:
- Remove inline unique property from account.email schema definition
- Add sparse unique index on account.email to enforce uniqueness at the database level