### PR TITLE
fix: update signup navigation to include option parameter

### DIFF
--- a/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
@@ -85,7 +85,7 @@ export const HomeTabsLayout: React.FC = () => {
 	};
 
 	const handleOnSignUp = () => {
-		navigate('/auth-redirect');
+		navigate('/auth-redirect?option=signup');
 	};
 
 	const handleCreateListing = useCreateListingNavigation();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Append '?option=signup' to the auth redirect URL in the HomeTabsLayout