### PR TITLE
remove debugging code

### DIFF
--- a/packages/cellix/mongoose-seedwork/src/mongoose-seedwork/mongo-repository.test.ts
+++ b/packages/cellix/mongoose-seedwork/src/mongoose-seedwork/mongo-repository.test.ts
@@ -282,7 +282,7 @@ test.for(mongoRepositoryFeature, ({ Background, Scenario, BeforeEachScenario }) 
 	});
 	Then('it should throw if mongoObj.save throws', () => {
 	  expect(thrownError).toBeInstanceOf(Error);
-	  expect(thrownError?.message).toContain('save failed'); // temporary update from tobe to toContain to debug E11000 error in deployed env
+	  expect(thrownError?.message).toBe('save failed');
 	});
   });
 

--- a/packages/cellix/mongoose-seedwork/src/mongoose-seedwork/mongo-repository.ts
+++ b/packages/cellix/mongoose-seedwork/src/mongoose-seedwork/mongo-repository.ts
@@ -81,10 +81,7 @@ export abstract class MongoRepositoryBase<
 			}
 		} catch (error) {
 			console.log(`Error saving item : ${String(error)}`);
-      // temporary update to debug E11000 error in deployed env
-			throw new Error(
-				`Error saving item  ${JSON.stringify(item)}: ${String(error)}`,
-			);
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Remove temporary debugging code in MongoRepositoryBase and adjust tests to expect the original error message

Enhancements:
- Remove temporary debugging wrapper in MongoRepositoryBase to throw original errors
- Simplify error expectation in tests to match exact error message

Tests:
- Update test assertion to expect exact error message instead of substring