### PR TITLE
fix: enforce unique constraints on account email and username fields

### DIFF
--- a/packages/sthrift/data-sources-mongoose-models/src/models/user/personal-user.model.ts
+++ b/packages/sthrift/data-sources-mongoose-models/src/models/user/personal-user.model.ts
@@ -116,11 +116,12 @@ export const PersonalUserAccountType: SchemaDefinition<PersonalUserAccount> = {
 		match: Patterns.EMAIL_PATTERN,
 		maxlength: 254,
 		required: true,
+		unique: true,
+		index: true,
 	},
 	username: {
 		type: String,
 		required: false,
-		unique: true,
 	},
 	profile: {
 		type: PersonalUserAccountProfileType,
@@ -152,7 +153,6 @@ const PersonalUserSchema = new Schema<
 			type: Schema.Types.ObjectId,
 			ref: PersonalUserRole.PersonalUserRoleModelName,
 			required: false,
-			index: true,
 		},
 		account: {
 			type: PersonalUserAccountType,
@@ -163,7 +163,10 @@ const PersonalUserSchema = new Schema<
 		schemaVersion: { type: String, required: true, default: '1.0.0' },
 	},
 	userOptions,
-).index({ 'account.email': 1 }, { sparse: true, unique: true });
+).index(
+	{ 'account.username': 1 },
+	{ unique: true, partialFilterExpression: { 'account.username': { $exists: true } } }, // enforce unique only when username exists
+);
 
 export const PersonalUserModelName: string = 'personal-users'; //TODO: This should be in singular form
 


### PR DESCRIPTION
## Summary by Sourcery

Update the PersonalUser Mongoose schema to enforce unique constraints on account email and username fields by adding field-level indexes and a conditional partial index, and clean up obsolete index configurations.

Enhancements:
- Add unique and indexed constraint to account.email field in the PersonalUser schema
- Configure a unique partial index on account.username to enforce uniqueness only when a username exists
- Remove outdated sparse unique email index and redundant role index definitions