### PR TITLE
fix: replace navigate calls with auth.signinRedirect for login and signup

### DIFF
--- a/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
@@ -81,11 +81,11 @@ export const HomeTabsLayout: React.FC = () => {
 	}, [auth.isAuthenticated]);
 
 	const handleOnLogin = () => {
-		navigate('/auth-redirect');
+		auth.signinRedirect();
 	};
 
 	const handleOnSignUp = () => {
-		navigate('/auth-redirect?option=signup');
+		auth.signinRedirect({ extraQueryParams: { option: "signup" } })
 	};
 
 	const handleCreateListing = useCreateListingNavigation();


### PR DESCRIPTION
## Summary by Sourcery

Use auth.signinRedirect to initiate login and signup flows instead of manual navigation

Bug Fixes:
- Replace navigate('/auth-redirect') with auth.signinRedirect() for login
- Replace navigate('/auth-redirect?option=signup') with auth.signinRedirect({extraQueryParams: {option: 'signup'}}) for signup