### PR TITLE
reverted: FORCE_DEPLOY_API and FORCE_DEPLOY_UI flags in deployment configuration

### DIFF
--- a/.force-deploy
+++ b/.force-deploy
@@ -2,8 +2,8 @@
 # Set FORCE_DEPLOY_* flags to control manual deployment overrides
 # Set to 'true' to force deployment, 'false' to disable
 
-FORCE_DEPLOY_API=true
-FORCE_DEPLOY_UI=true
+FORCE_DEPLOY_API=false
+FORCE_DEPLOY_UI=false
 FORCE_DEPLOY_DOCS=false
 
 # Developers: Change any value to 'true' to force deployment of that package


### PR DESCRIPTION
## Summary by Sourcery

Revert the FORCE_DEPLOY_API and FORCE_DEPLOY_UI flags in the deployment configuration to restore previous behavior

Chores:
- Remove forced API deployment flag from .force-deploy
- Remove forced UI deployment flag from .force-deploy