### PR TITLE
fix: integrate HandleLogoutMockForMockAuth in development and HandleLogout in production environments

### DIFF
--- a/.force-deploy
+++ b/.force-deploy
@@ -2,8 +2,8 @@
 # Set FORCE_DEPLOY_* flags to control manual deployment overrides
 # Set to 'true' to force deployment, 'false' to disable
 
-FORCE_DEPLOY_API=false
-FORCE_DEPLOY_UI=false
+FORCE_DEPLOY_API=true
+FORCE_DEPLOY_UI=true
 FORCE_DEPLOY_DOCS=false
 
 # Developers: Change any value to 'true' to force deployment of that package

--- a/apps/ui-sharethrift/src/App.tsx
+++ b/apps/ui-sharethrift/src/App.tsx
@@ -11,13 +11,19 @@ const authSection = (
 	</RequireAuth>
 );
 
+const signupSection = (
+    <RequireAuth redirectPath="/" forceLogin={true}>
+        <SignupRoutes />
+    </RequireAuth>
+);
+
 const App: React.FC = () => {
 	return (
 		<ApolloConnection>
 			<Routes>
 				<Route path="/*" element={<HomeRoutes />} />
 				<Route path="/auth-redirect" element={authSection} />
-				<Route path="/signup/*" element={<SignupRoutes />} />
+				<Route path="/signup/*" element={signupSection} />
 				<Route path="/" element={<Navigate to="/home" replace />} />
 			</Routes>
 		</ApolloConnection>

--- a/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
+import { HandleLogout,
+HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
 import { Footer, Header, Navigation } from '@sthrift/ui-components';
 import { useCreateListingNavigation } from './components/create-listing/hooks/use-create-listing-navigation.ts';
+import { useApolloClient } from '@apollo/client/react';
 
 export const HomeTabsLayout: React.FC = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const auth = useAuth();
+    const apolloClient = useApolloClient();
+    const { NODE_ENV } = process.env
 
 	// Map nav keys to routes as defined in index.tsx
 	const routeMap: Record<string, string> = {
@@ -91,7 +95,11 @@ export const HomeTabsLayout: React.FC = () => {
 	const handleCreateListing = useCreateListingNavigation();
 
 	const handleLogOut = () => {
-		HandleLogoutMockForMockAuth(auth);
+		if (NODE_ENV === 'development') {
+			HandleLogoutMockForMockAuth(auth);
+			return;
+		}
+		HandleLogout(auth, apolloClient);
 	};
 
 	return (

--- a/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/section-layout.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { HandleLogout,
-HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
+import { HandleLogout } from '../../shared/handle-logout.ts';
 import { Footer, Header, Navigation } from '@sthrift/ui-components';
 import { useCreateListingNavigation } from './components/create-listing/hooks/use-create-listing-navigation.ts';
 import { useApolloClient } from '@apollo/client/react';
@@ -12,7 +11,6 @@ export const HomeTabsLayout: React.FC = () => {
 	const location = useLocation();
 	const auth = useAuth();
     const apolloClient = useApolloClient();
-    const { NODE_ENV } = process.env
 
 	// Map nav keys to routes as defined in index.tsx
 	const routeMap: Record<string, string> = {
@@ -95,11 +93,7 @@ export const HomeTabsLayout: React.FC = () => {
 	const handleCreateListing = useCreateListingNavigation();
 
 	const handleLogOut = () => {
-		if (NODE_ENV === 'development') {
-			HandleLogoutMockForMockAuth(auth);
-			return;
-		}
-		HandleLogout(auth, apolloClient);
+		HandleLogout(auth, apolloClient, window.location.origin);
 	};
 
 	return (

--- a/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { Footer, Header } from '@sthrift/ui-components';
 import { useAuth } from 'react-oidc-context';
 import { HandleLogout, HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
@@ -10,21 +10,21 @@ interface SectionLayoutProps {}
 
 export const SectionLayout: React.FC<SectionLayoutProps> = (_props) => {
 	const auth = useAuth();
-	const navigate = useNavigate();
 	const apolloClient = useApolloClient();
+    const { NODE_ENV } = process.env
 
 	const handleOnLogin = () => {
-		navigate('/auth-redirect');
+		auth.signinRedirect();
 	};
 
 	const handleOnSignUp = () => {
-		navigate('/auth-redirect');
+		auth.signinRedirect({ extraQueryParams: { option: "signup" } })
 	};
 
 	const handleCreateListing = useCreateListingNavigation();
 
 	const handleLogOut = () => {
-		if (process.env['NODE_ENV'] === 'development') {
+		if (NODE_ENV === 'development') {
 			HandleLogoutMockForMockAuth(auth);
 			return;
 		}

--- a/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { Footer, Header } from '@sthrift/ui-components';
 import { useAuth } from 'react-oidc-context';
-import { HandleLogout, HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
+import { HandleLogout } from '../../shared/handle-logout.ts';
 import { useApolloClient } from '@apollo/client/react';
 import { useCreateListingNavigation } from '../home/components/create-listing/hooks/use-create-listing-navigation.ts';
 
@@ -11,7 +11,6 @@ interface SectionLayoutProps {}
 export const SectionLayout: React.FC<SectionLayoutProps> = (_props) => {
 	const auth = useAuth();
 	const apolloClient = useApolloClient();
-    const { NODE_ENV } = process.env
 
 	const handleOnLogin = () => {
 		auth.signinRedirect();
@@ -24,11 +23,7 @@ export const SectionLayout: React.FC<SectionLayoutProps> = (_props) => {
 	const handleCreateListing = useCreateListingNavigation();
 
 	const handleLogOut = () => {
-		if (NODE_ENV === 'development') {
-			HandleLogoutMockForMockAuth(auth);
-			return;
-		}
-		HandleLogout(auth, apolloClient);
+        HandleLogout(auth, apolloClient, window.location.origin);
 	};
 
 	return (

--- a/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/signup/section-layout.tsx
@@ -1,7 +1,8 @@
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Footer, Header } from '@sthrift/ui-components';
 import { useAuth } from 'react-oidc-context';
-import { HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
+import { HandleLogout, HandleLogoutMockForMockAuth } from '../../shared/handle-logout.ts';
+import { useApolloClient } from '@apollo/client/react';
 import { useCreateListingNavigation } from '../home/components/create-listing/hooks/use-create-listing-navigation.ts';
 
 // biome-ignore lint/suspicious/noEmptyInterface: <explanation>
@@ -10,6 +11,7 @@ interface SectionLayoutProps {}
 export const SectionLayout: React.FC<SectionLayoutProps> = (_props) => {
 	const auth = useAuth();
 	const navigate = useNavigate();
+	const apolloClient = useApolloClient();
 
 	const handleOnLogin = () => {
 		navigate('/auth-redirect');
@@ -22,7 +24,11 @@ export const SectionLayout: React.FC<SectionLayoutProps> = (_props) => {
 	const handleCreateListing = useCreateListingNavigation();
 
 	const handleLogOut = () => {
-		HandleLogoutMockForMockAuth(auth);
+		if (process.env['NODE_ENV'] === 'development') {
+			HandleLogoutMockForMockAuth(auth);
+			return;
+		}
+		HandleLogout(auth, apolloClient);
 	};
 
 	return (

--- a/apps/ui-sharethrift/src/components/shared/handle-logout.ts
+++ b/apps/ui-sharethrift/src/components/shared/handle-logout.ts
@@ -21,9 +21,3 @@ export const HandleLogout = (
 
 	auth.signoutRedirect();
 };
-
-export const HandleLogoutMockForMockAuth = (auth: AuthContextProps) => {
-	auth.removeUser();
-	clearStorage();
-	window.location.href = '/';
-};


### PR DESCRIPTION
## Summary by Sourcery

Use direct OIDC sign-in redirects for login and signup, and unify logout handling by removing the mock implementation and invoking HandleLogout with the Apollo client and origin

Enhancements:
- Replace navigate('/auth-redirect') with auth.signinRedirect calls in login and signup flows
- Remove HandleLogoutMockForMockAuth and consolidate logout logic into the shared HandleLogout function
- Import and pass the Apollo client and window.origin into HandleLogout in layout components to support cache clearing on logout