### PR TITLE
fix error handling for token validation

### DIFF
--- a/packages/sthrift/service-token-validation/src/index.ts
+++ b/packages/sthrift/service-token-validation/src/index.ts
@@ -59,12 +59,20 @@ export class ServiceTokenValidation implements ServiceBase<TokenValidation> {
 	): Promise<TokenValidationResult<ClaimsType> | null> {
 		// Try each config key for verification
 		for (const configKey of this.tokenSettings.keys()) {
-			const result = await this.tokenVerifier.getVerifiedJwt(token, configKey);
-			if (result?.payload) {
-				return {
-					verifiedJwt: result.payload as ClaimsType,
-					openIdConfigKey: configKey,
-				};
+			try {
+				const result = await this.tokenVerifier.getVerifiedJwt(
+					token,
+					configKey,
+				);
+				if (result?.payload) {
+					return {
+						verifiedJwt: result.payload as ClaimsType,
+						openIdConfigKey: configKey,
+					};
+				}
+			} catch {
+				// Required error handling, logging omitted to prevent flooding logs
+				continue;
 			}
 		}
 		return null;


### PR DESCRIPTION
small fix: try/catch block

## Summary by Sourcery

Bug Fixes:
- Wrap JWT verification in a try/catch block to catch errors and continue iterating through token settings instead of failing