### PR TITLE
fix: add main field to @sthrift/api for e18e compliance

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "description": "",
     "type": "module",
+    "main": "dist/src/index.js",
     "exports": {
         ".": {
             "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
- Added 'main' field to package.json pointing to dist/src/index.js
- Required for Azure Functions runtime to resolve entry point
- Fixes e18e configuration validation errors
- Also required for proper ESM/CJS module resolution