### PR TITLE
fix duplication+navigation after onboarding

### DIFF
--- a/apps/ui-sharethrift/src/components/shared/use-has-completed-onboarding-check.ts
+++ b/apps/ui-sharethrift/src/components/shared/use-has-completed-onboarding-check.ts
@@ -23,7 +23,7 @@ export function useOnboardingRedirect(
 					'Redirecting to home because user has completed onboarding',
 				);
 				// User onboarded, trying to access any onboarding page: redirect to home
-				navigate('/home', { replace: true });
+				navigate('/', { replace: true });
 			}
 		}
 

--- a/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
+++ b/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
@@ -2,6 +2,44 @@ import type { GraphContext } from '../../../init/context.ts';
 import type { Resolvers } from '../../builder/generated.js';
 import { PopulateUserFromField } from '../../resolver-helper.ts';
 
+// Helper type for paged arguments
+export type PagedArgs = {
+	page: number;
+	pageSize: number;
+	searchText?: string;
+	statusFilters?: string[];
+	sorter?: { field: string; order: 'ascend' | 'descend' };
+	sharerId?: string;
+};
+
+// Helper function to construct pagedArgs
+function buildPagedArgs(
+	args: {
+		page: number;
+		pageSize: number;
+		searchText?: string | null;
+		statusFilters?: readonly string[] | null;
+		sorter?: { field: string; order: string } | null;
+	},
+	extra?: Partial<PagedArgs>,
+): PagedArgs {
+	return {
+		page: args.page,
+		pageSize: args.pageSize,
+		...(args.searchText ? { searchText: args.searchText } : {}),
+		...(args.statusFilters ? { statusFilters: [...args.statusFilters] } : {}),
+		...(args.sorter
+			? {
+					sorter: {
+						field: args.sorter.field,
+						order: args.sorter.order as 'ascend' | 'descend',
+					},
+				}
+			: {}),
+		...extra,
+	};
+}
+
 const itemListingResolvers: Resolvers = {
 	ItemListing: {
 		sharer: PopulateUserFromField('sharer'),
@@ -17,32 +55,8 @@ const itemListingResolvers: Resolvers = {
 						email: email,
 					}).then((user) => (user ? user.id : undefined));
 			}
-			type PagedArgs = {
-				page: number;
-				pageSize: number;
-				searchText?: string;
-				statusFilters?: string[];
-				sorter?: { field: string; order: 'ascend' | 'descend' };
-				sharerId?: string;
-			};
 
-			const pagedArgs: PagedArgs = {
-				page: args.page,
-				pageSize: args.pageSize,
-				...(args.searchText != null ? { searchText: args.searchText } : {}),
-				...(args.statusFilters != null
-					? { statusFilters: [...args.statusFilters] }
-					: {}),
-				...(args.sorter != null
-					? {
-							sorter: {
-								field: args.sorter.field,
-								order: args.sorter.order as 'ascend' | 'descend',
-							},
-						}
-					: {}),
-				...(sharerId && { sharerId }),
-			};
+			const pagedArgs = buildPagedArgs(args, sharerId ? { sharerId } : {});
 
 			return await context.applicationServices.Listing.ItemListing.queryPaged(
 				pagedArgs,
@@ -59,30 +73,7 @@ const itemListingResolvers: Resolvers = {
 		},
 		adminListings: async (_parent, args, context) => {
 			// Admin-note: role-based authorization should be implemented here (security)
-			type PagedArgs = {
-				page: number;
-				pageSize: number;
-				searchText?: string;
-				statusFilters?: string[];
-				sorter?: { field: string; order: 'ascend' | 'descend' };
-			};
-
-			const pagedArgs: PagedArgs = {
-				page: args.page,
-				pageSize: args.pageSize,
-				...(args.searchText != null ? { searchText: args.searchText } : {}),
-				...(args.statusFilters != null
-					? { statusFilters: [...args.statusFilters] }
-					: {}),
-				...(args.sorter != null
-					? {
-							sorter: {
-								field: args.sorter.field,
-								order: args.sorter.order as 'ascend' | 'descend',
-							},
-						}
-					: {}),
-			};
+			const pagedArgs = buildPagedArgs(args);
 
 			return await context.applicationServices.Listing.ItemListing.queryPaged(
 				pagedArgs,


### PR DESCRIPTION
## Summary by Sourcery

Deduplicate and centralize construction of paginated listing query arguments and adjust onboarding completion navigation target.

Bug Fixes:
- Update onboarding completion redirect to navigate to the root path instead of the home sub-route.

Enhancements:
- Introduce a shared helper type and function to build paginated listing query arguments reused by multiple listing resolvers to reduce duplication.