### PR TITLE
use compiled copy-assets in build and fix iframe asset paths

### DIFF
--- a/packages/cellix/mock-payment-server/README.md
+++ b/packages/cellix/mock-payment-server/README.md
@@ -1,6 +1,7 @@
 # Payment Mock Server
 A simple Express-based mock server for payment API testing.
 
+
 ## Endpoints
 - GET /pts/v2/public-key — generatePublicKey endpoint
 - POST /pts/v2/customers — createCustomerProfile endpoint

--- a/packages/cellix/mock-payment-server/package.json
+++ b/packages/cellix/mock-payment-server/package.json
@@ -23,7 +23,7 @@
 	},
 	"scripts": {
 		"start": "node dist/src/index.js",
-		"build": "tsc --build && node src/copy-assets.ts",
+		"build": "tsc --build && node dist/src/copy-assets.js",
 		"clean": "rimraf node_modules package-lock.json dist"
 	}
 }

--- a/packages/cellix/mock-payment-server/src/copy-assets.ts
+++ b/packages/cellix/mock-payment-server/src/copy-assets.ts
@@ -5,8 +5,8 @@ import path from 'path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const src = join(__dirname, 'iframe.min.js');
-const dest = join(__dirname, '../dist/src/iframe.min.js');
+const src = join(__dirname, '../../src/iframe.min.js');
+const dest = join(__dirname, '../src/iframe.min.js');
 
 copyFileSync(src, dest);
 console.log('Copied iframe.min.js to dist');


### PR DESCRIPTION
## Summary by Sourcery

Update the mock payment server build to use the compiled asset-copy script and correct iframe asset paths.

Enhancements:
- Adjust iframe asset copy paths so the script sources the file from the shared src directory and writes it to the expected location in the package.

Build:
- Change the mock payment server build script to run the compiled copy-assets JavaScript from the dist output instead of the TypeScript source.