### PR TITLE
fixed organization and return data for reservation-request resolver

### DIFF
--- a/apps/ui-sharethrift/package.json
+++ b/apps/ui-sharethrift/package.json
@@ -12,7 +12,7 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"test": "vitest run",
-		"test:coverage:ui": "vitest run --coverage",
+		"test:coverage": "vitest run --coverage",
 		"test:watch": "vitest"
 	},
 	"dependencies": {
@@ -28,7 +28,7 @@
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
 		"react-oidc-context": "^3.3.0",
-		"react-router-dom": "^7.8.0",
+		"react-router-dom": "^7.12.0",
 		"rxjs": "^7.8.2"
 	},
 	"devDependencies": {
@@ -47,7 +47,8 @@
 		"@types/react": "^19.1.9",
 		"@types/react-dom": "^19.1.7",
 		"@vitejs/plugin-react": "^4.7.0",
-		"@vitest/coverage-v8": "catalog:",
+		"@vitest/browser": "3.2.4",
+		"@vitest/coverage-v8": "^3.2.4",
 		"eslint": "^9.30.1",
 		"eslint-plugin-react-hooks": "^5.2.0",
 		"eslint-plugin-react-refresh": "^0.4.20",
@@ -55,8 +56,8 @@
 		"storybook": "catalog:",
 		"typescript": "~5.8.3",
 		"typescript-eslint": "^8.35.1",
-		"vite": "catalog:",
-		"vitest": "catalog:"
+		"vite": "^7.1.2",
+		"vitest": "^3.2.4"
 	},
 	"license": "MIT"
 }

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.graphql
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.graphql
@@ -23,12 +23,26 @@ query HomeRequestsTableContainerMyListingsRequests(
   }
 }
 
-fragment HomeRequestsTableContainerRequestFields on ListingRequest {
+fragment HomeRequestsTableContainerRequestFields on ReservationRequest {
   id
-  title
-  image
-  requestedBy
-  requestedOn
-  reservationPeriod
-  status
+  listing {
+    title
+    images
+  }
+  reserver {
+    ... on PersonalUser {
+      account {
+        username
+      }
+    }
+    ... on AdminUser {
+      account {
+        username
+      }
+    }
+  }
+  createdAt
+  reservationPeriodStart
+  reservationPeriodEnd
+  state
 }

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.stories.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.stories.tsx
@@ -10,24 +10,44 @@ import { HomeRequestsTableContainerMyListingsRequestsDocument } from '../../../.
 const mockRequests = {
 	items: [
 		{
-			__typename: 'MyListingRequest',
+			__typename: 'ReservationRequest',
 			id: '1',
-			title: 'Cordless Drill',
-			image: '/assets/item-images/projector.png',
-			requestedOn: '2025-01-15',
-			reservationPeriod: '2025-01-20 - 2025-01-25',
-			status: 'Pending',
-			requestedBy: 'John Doe',
+			createdAt: new Date('2025-01-15T10:00:00.000Z'),
+			reservationPeriodStart: new Date('2025-01-20T00:00:00.000Z'),
+			reservationPeriodEnd: new Date('2025-01-25T00:00:00.000Z'),
+			state: 'Pending',
+			listing: {
+				__typename: 'ItemListing',
+				title: 'Cordless Drill',
+				images: ['/assets/item-images/projector.png'],
+			},
+			reserver: {
+				__typename: 'PersonalUser',
+				account: {
+					__typename: 'PersonalUserAccount',
+					username: 'johndoe',
+				},
+			},
 		},
 		{
-			__typename: 'MyListingRequest',
+			__typename: 'ReservationRequest',
 			id: '2',
-			title: 'Electric Guitar',
-			image: '/assets/item-images/projector.png',
-			requestedOn: '2025-02-01',
-			reservationPeriod: '2025-02-10 - 2025-02-15',
-			status: 'Accepted',
-			requestedBy: 'Jane Smith',
+			createdAt: new Date('2025-02-01T14:30:00.000Z'),
+			reservationPeriodStart: new Date('2025-02-10T00:00:00.000Z'),
+			reservationPeriodEnd: new Date('2025-02-15T00:00:00.000Z'),
+			state: 'Accepted',
+			listing: {
+				__typename: 'ItemListing',
+				title: 'Electric Guitar',
+				images: ['/assets/item-images/projector.png'],
+			},
+			reserver: {
+				__typename: 'PersonalUser',
+				account: {
+					__typename: 'PersonalUserAccount',
+					username: 'janesmith',
+				},
+			},
 		},
 	],
 	total: 2,
@@ -209,7 +229,14 @@ export const WithSearchFilter: Story = {
 				{
 					request: {
 						query: HomeRequestsTableContainerMyListingsRequestsDocument,
-						variables: () => true,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
 					},
 					maxUsageCount: Number.POSITIVE_INFINITY,
 					result: {
@@ -253,7 +280,14 @@ export const WithStatusFilter: Story = {
 				{
 					request: {
 						query: HomeRequestsTableContainerMyListingsRequestsDocument,
-						variables: () => true,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
 					},
 					maxUsageCount: Number.POSITIVE_INFINITY,
 					result: {
@@ -292,7 +326,14 @@ export const WithSorting: Story = {
 				{
 					request: {
 						query: HomeRequestsTableContainerMyListingsRequestsDocument,
-						variables: () => true,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
 					},
 					maxUsageCount: Number.POSITIVE_INFINITY,
 					result: {

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.stories.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.stories.tsx
@@ -447,3 +447,340 @@ export const NoData: Story = {
 		);
 	},
 };
+
+export const DataMappingEdgeCases: Story = {
+	args: {
+		currentPage: 1,
+		onPageChange: fn(),
+	},
+	parameters: {
+		apolloClient: {
+			mocks: [
+				{
+					request: {
+						query: HomeRequestsTableContainerMyListingsRequestsDocument,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
+					},
+					result: {
+						data: {
+							myListingsRequests: {
+								items: [
+									{
+										__typename: 'ReservationRequest',
+										id: '1',
+										createdAt: new Date('2025-01-15T10:00:00.000Z'),
+										reservationPeriodStart: null,
+										reservationPeriodEnd: null,
+										state: null,
+										listing: null, // Missing listing data
+										reserver: null, // Missing reserver data
+									},
+									{
+										__typename: 'ReservationRequest',
+										id: '2',
+										createdAt: new Date('2025-01-16T10:00:00.000Z'),
+										reservationPeriodStart: new Date('2025-01-20T00:00:00.000Z'),
+										reservationPeriodEnd: new Date('2025-01-25T00:00:00.000Z'),
+										state: 'Pending',
+										listing: {
+											__typename: 'ItemListing',
+											title: null, // Missing title
+											images: [], // Empty images array
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: null, // Missing account
+										},
+									},
+									{
+										__typename: 'ReservationRequest',
+										id: '3',
+										createdAt: new Date('2025-01-17T10:00:00.000Z'),
+										reservationPeriodStart: new Date('2025-01-21T00:00:00.000Z'),
+										reservationPeriodEnd: new Date('2025-01-26T00:00:00.000Z'),
+										state: 'Accepted',
+										listing: {
+											__typename: 'ItemListing',
+											title: 'Valid Title',
+											images: ['/assets/item-images/valid.png'],
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: {
+												__typename: 'PersonalUserAccount',
+												username: null, // Missing username
+											},
+										},
+									},
+								],
+								total: 3,
+							},
+						},
+					},
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for data to load
+		await waitFor(
+			() => {
+				expect(canvas.queryAllByText(/Unknown/i).length).toBeGreaterThan(0);
+			},
+			{ timeout: 3000 },
+		);
+
+		// Test fallback values for missing data
+		expect(canvas.getByText('Unknown')).toBeInTheDocument(); // Missing listing title
+		expect(canvas.getByText('@unknown')).toBeInTheDocument(); // Missing username
+		expect(canvas.getAllByText('Unknown').length).toBeGreaterThan(1); // Multiple fallbacks
+
+		// Test valid data still renders correctly
+		expect(canvas.getByText('Valid Title')).toBeInTheDocument();
+		expect(canvas.getByText('Accepted')).toBeInTheDocument();
+	},
+};
+
+export const DateFormatting: Story = {
+	args: {
+		currentPage: 1,
+		onPageChange: fn(),
+	},
+	parameters: {
+		apolloClient: {
+			mocks: [
+				{
+					request: {
+						query: HomeRequestsTableContainerMyListingsRequestsDocument,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
+					},
+					result: {
+						data: {
+							myListingsRequests: {
+								items: [
+									{
+										__typename: 'ReservationRequest',
+										id: '1',
+										createdAt: new Date('2025-01-15T10:30:45.123Z'),
+										reservationPeriodStart: new Date('2025-01-20T09:15:30.000Z'),
+										reservationPeriodEnd: new Date('2025-01-25T18:45:00.000Z'),
+										state: 'Pending',
+										listing: {
+											__typename: 'ItemListing',
+											title: 'Test Item',
+											images: ['/assets/item-images/test.png'],
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: {
+												__typename: 'PersonalUserAccount',
+												username: 'testuser',
+											},
+										},
+									},
+								],
+								total: 1,
+							},
+						},
+					},
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for data to load
+		await waitFor(
+			() => {
+				expect(canvas.getByText('Test Item')).toBeInTheDocument();
+			},
+			{ timeout: 3000 },
+		);
+
+		// Test date formatting - should show date part only (YYYY-MM-DD)
+		expect(canvas.getByText('2025-01-20 to 2025-01-25')).toBeInTheDocument();
+
+		// Test that full ISO string is used for requestedOn (not just date part)
+		const requestedOnCell = canvas.getByText('2025-01-15T10:30:45.123Z');
+		expect(requestedOnCell).toBeInTheDocument();
+	},
+};
+
+export const StateFilteringInteraction: Story = {
+	args: {
+		currentPage: 1,
+		onPageChange: fn(),
+	},
+	parameters: {
+		apolloClient: {
+			mocks: [
+				{
+					request: {
+						query: HomeRequestsTableContainerMyListingsRequestsDocument,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: ['Pending'],
+							sorter: { field: '', order: '' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
+					},
+					result: {
+						data: {
+							myListingsRequests: {
+								items: [
+									{
+										__typename: 'ReservationRequest',
+										id: '1',
+										createdAt: new Date('2025-01-15T10:00:00.000Z'),
+										reservationPeriodStart: new Date('2025-01-20T00:00:00.000Z'),
+										reservationPeriodEnd: new Date('2025-01-25T00:00:00.000Z'),
+										state: 'Pending',
+										listing: {
+											__typename: 'ItemListing',
+											title: 'Filtered Item',
+											images: ['/assets/item-images/filtered.png'],
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: {
+												__typename: 'PersonalUserAccount',
+												username: 'filtereduser',
+											},
+										},
+									},
+								],
+								total: 1,
+							},
+						},
+					},
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for filtered data to load
+		await waitFor(
+			() => {
+				expect(canvas.getByText('Filtered Item')).toBeInTheDocument();
+			},
+			{ timeout: 3000 },
+		);
+
+		// Verify the filtered item shows correct status
+		expect(canvas.getByText('Pending')).toBeInTheDocument();
+		expect(canvas.getByText('@filtereduser')).toBeInTheDocument();
+	},
+};
+
+export const SortingInteraction: Story = {
+	args: {
+		currentPage: 1,
+		onPageChange: fn(),
+	},
+	parameters: {
+		apolloClient: {
+			mocks: [
+				{
+					request: {
+						query: HomeRequestsTableContainerMyListingsRequestsDocument,
+						variables: {
+							page: 1,
+							pageSize: 6,
+							searchText: '',
+							statusFilters: [],
+							sorter: { field: 'title', order: 'ascend' },
+							sharerId: '6324a3f1e3e4e1e6a8e1d8b1',
+						},
+					},
+					result: {
+						data: {
+							myListingsRequests: {
+								items: [
+									{
+										__typename: 'ReservationRequest',
+										id: '1',
+										createdAt: new Date('2025-01-15T10:00:00.000Z'),
+										reservationPeriodStart: new Date('2025-01-20T00:00:00.000Z'),
+										reservationPeriodEnd: new Date('2025-01-25T00:00:00.000Z'),
+										state: 'Pending',
+										listing: {
+											__typename: 'ItemListing',
+											title: 'Apple MacBook',
+											images: ['/assets/item-images/macbook.png'],
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: {
+												__typename: 'PersonalUserAccount',
+												username: 'user1',
+											},
+										},
+									},
+									{
+										__typename: 'ReservationRequest',
+										id: '2',
+										createdAt: new Date('2025-01-16T10:00:00.000Z'),
+										reservationPeriodStart: new Date('2025-01-21T00:00:00.000Z'),
+										reservationPeriodEnd: new Date('2025-01-26T00:00:00.000Z'),
+										state: 'Accepted',
+										listing: {
+											__typename: 'ItemListing',
+											title: 'Zeiss Camera',
+											images: ['/assets/item-images/camera.png'],
+										},
+										reserver: {
+											__typename: 'PersonalUser',
+											account: {
+												__typename: 'PersonalUserAccount',
+												username: 'user2',
+											},
+										},
+									},
+								],
+								total: 2,
+							},
+						},
+					},
+				},
+			],
+		},
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		// Wait for sorted data to load
+		await waitFor(
+			() => {
+				expect(canvas.getByText('Apple MacBook')).toBeInTheDocument();
+			},
+			{ timeout: 3000 },
+		);
+
+		// Verify both items are present (sorted alphabetically)
+		expect(canvas.getByText('Apple MacBook')).toBeInTheDocument();
+		expect(canvas.getByText('Zeiss Camera')).toBeInTheDocument();
+		expect(canvas.getByText('Pending')).toBeInTheDocument();
+		expect(canvas.getByText('Accepted')).toBeInTheDocument();
+	},
+};

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
@@ -41,8 +41,10 @@ export const RequestsTableContainer: React.FC<RequestsTableContainerProps> = ({
 		title: request.listing?.title || 'Unknown',
 		image: request.listing?.images?.[0] || null,
 		requestedBy: `@${request.reserver?.account?.username || 'unknown'}`,
-		requestedOn: request.createdAt,
-		reservationPeriod: `${request.reservationPeriodStart.toISOString().split('T')[0]} to ${request.reservationPeriodEnd.toISOString().split('T')[0]}`,
+		requestedOn: request.createdAt?.toISOString(),
+		reservationPeriod: request.reservationPeriodStart && request.reservationPeriodEnd
+			? `${request.reservationPeriodStart.toISOString().split('T')[0]} to ${request.reservationPeriodEnd.toISOString().split('T')[0]}`
+			: 'Unknown',
 		status: request.state || 'Unknown',
 	}));
 	const total = data?.myListingsRequests?.total ?? 0;

--- a/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
+++ b/apps/ui-sharethrift/src/components/layouts/home/my-listings/components/requests-table.container.tsx
@@ -36,7 +36,15 @@ export const RequestsTableContainer: React.FC<RequestsTableContainerProps> = ({
 		},
 	);
 
-	const requests = data?.myListingsRequests?.items ?? [];
+	const requests = (data?.myListingsRequests?.items ?? []).map((request) => ({
+		id: request.id,
+		title: request.listing?.title || 'Unknown',
+		image: request.listing?.images?.[0] || null,
+		requestedBy: `@${request.reserver?.account?.username || 'unknown'}`,
+		requestedOn: request.createdAt,
+		reservationPeriod: `${request.reservationPeriodStart.toISOString().split('T')[0]} to ${request.reservationPeriodEnd.toISOString().split('T')[0]}`,
+		status: request.state || 'Unknown',
+	}));
 	const total = data?.myListingsRequests?.total ?? 0;
 
 	const handleSearch = (value: string) => {

--- a/packages/cellix/ui-core/package.json
+++ b/packages/cellix/ui-core/package.json
@@ -33,7 +33,7 @@
 		"react": ">=18.0.0",
 		"react-dom": ">=18.0.0",
 		"react-oidc-context": ">=2.0.0",
-		"react-router-dom": ">=6.0.0"
+		"react-router-dom": "7.12.0"
 	},
 	"devDependencies": {
 		"@cellix/typescript-config": "workspace:*",
@@ -49,7 +49,7 @@
 		"@vitest/coverage-v8": "catalog:",
 		"jsdom": "^26.1.0",
 		"react-oidc-context": "^3.3.0",
-		"react-router-dom": "^7.9.3",
+		"react-router-dom": "^7.12.0",
 		"rimraf": "^6.0.1",
 		"storybook": "catalog:",
 		"typescript": "^5.8.3",

--- a/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/features/query-listing-requests-by-sharer-id.feature
+++ b/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/features/query-listing-requests-by-sharer-id.feature
@@ -11,3 +11,27 @@ Feature: Query Listing Reservation Requests By Sharer ID
     And the sharer has no reservation requests
     When the queryListingRequestsBySharerId command is executed
     Then an empty array should be returned
+
+  Scenario: Retrieving reservation requests with pagination
+    Given a valid sharer ID "user-123"
+    And the sharer has listings with 10 reservation requests
+    When the queryListingRequestsBySharerId command is executed with page 2 and pageSize 3
+    Then 3 reservation requests should be returned for page 2
+
+  Scenario: Retrieving reservation requests with search filter
+    Given a valid sharer ID "user-123"
+    And the sharer has listings with reservation requests for different items
+    When the queryListingRequestsBySharerId command is executed with searchText "camera"
+    Then only reservation requests for listings containing "camera" should be returned
+
+  Scenario: Retrieving reservation requests with status filters
+    Given a valid sharer ID "user-123"
+    And the sharer has listings with reservation requests in different states
+    When the queryListingRequestsBySharerId command is executed with statusFilters ["Approved"]
+    Then only reservation requests with "Approved" status should be returned
+
+  Scenario: Retrieving reservation requests with sorting
+    Given a valid sharer ID "user-123"
+    And the sharer has listings with reservation requests created at different times
+    When the queryListingRequestsBySharerId command is executed with sorter field "createdAt" order "descend"
+    Then reservation requests should be sorted by createdAt in descending order

--- a/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/index.ts
+++ b/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/index.ts
@@ -16,7 +16,12 @@ export interface ReservationRequestApplicationService {
     queryActiveByReserverIdAndListingId: (command: ReservationRequestQueryActiveByReserverIdAndListingIdCommand) => Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference | null>,
     queryOverlapByListingIdAndReservationPeriod: (command: ReservationRequestQueryOverlapByListingIdAndReservationPeriodCommand) => Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[]>,
     queryActiveByListingId: (command: ReservationRequestQueryActiveByListingIdCommand) => Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[]>,
-    queryListingRequestsBySharerId: (command: ReservationRequestQueryListingRequestsBySharerIdCommand) => Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[]>,
+    queryListingRequestsBySharerId: (command: ReservationRequestQueryListingRequestsBySharerIdCommand) => Promise<{
+        items: Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[];
+        total: number;
+        page: number;
+        pageSize: number;
+    }>,
     create: (command: ReservationRequestCreateCommand) => Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference>,
 }
 

--- a/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.test.ts
+++ b/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.test.ts
@@ -148,7 +148,7 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 				},
 			);
 
-			Then('a paginated result should be returned', () => {
+			Then('4 reservation requests should be returned', () => {
 				expect(result).toBeDefined();
 				expect(result).toHaveProperty('items');
 				expect(result).toHaveProperty('total');
@@ -270,7 +270,7 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 				},
 			);
 
-			Then('an empty paginated result should be returned', () => {
+			Then('an empty array should be returned', () => {
 				expect(result).toBeDefined();
 				expect(result).toHaveProperty('items');
 				expect(result).toHaveProperty('total');

--- a/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.test.ts
+++ b/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.test.ts
@@ -53,29 +53,90 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 					{
 						id: 'req-1',
 						state: 'Requested',
-						listing: { id: 'listing-1', sharer: { id: 'sharer-123' } },
+						createdAt: new Date('2024-01-01'),
+						reservationPeriodStart: new Date('2024-02-01'),
+						reservationPeriodEnd: new Date('2024-02-05'),
+						listing: {
+							id: 'listing-1',
+							title: 'Test Listing 1',
+							images: ['image1.jpg'],
+							sharer: { id: 'sharer-123' }
+						},
+						reserver: {
+							id: 'reserver-1',
+							account: {
+								username: 'johndoe'
+							}
+						}
 					},
 					{
 						id: 'req-2',
-						state: 'Requested',
-						listing: { id: 'listing-1', sharer: { id: 'sharer-123' } },
+						state: 'Approved',
+						createdAt: new Date('2024-01-02'),
+						reservationPeriodStart: new Date('2024-02-10'),
+						reservationPeriodEnd: new Date('2024-02-15'),
+						listing: {
+							id: 'listing-1',
+							title: 'Test Listing 1',
+							images: ['image1.jpg'],
+							sharer: { id: 'sharer-123' }
+						},
+						reserver: {
+							id: 'reserver-2',
+							account: {
+								username: 'janesmith'
+							}
+						}
 					},
 					{
 						id: 'req-3',
 						state: 'Requested',
-						listing: { id: 'listing-2', sharer: { id: 'sharer-123' } },
+						createdAt: new Date('2024-01-03'),
+						reservationPeriodStart: new Date('2024-03-01'),
+						reservationPeriodEnd: new Date('2024-03-03'),
+						listing: {
+							id: 'listing-2',
+							title: 'Test Listing 2',
+							images: ['image2.jpg'],
+							sharer: { id: 'sharer-123' }
+						},
+						reserver: {
+							id: 'reserver-3',
+							account: {
+								username: 'bobjohnson'
+							}
+						}
 					},
 					{
 						id: 'req-4',
-						state: 'Requested',
-						listing: { id: 'listing-2', sharer: { id: 'sharer-123' } },
+						state: 'Rejected',
+						createdAt: new Date('2024-01-04'),
+						reservationPeriodStart: new Date('2024-03-10'),
+						reservationPeriodEnd: new Date('2024-03-12'),
+						listing: {
+							id: 'listing-2',
+							title: 'Test Listing 2',
+							images: [],
+							sharer: { id: 'sharer-123' }
+						},
+						reserver: {
+							id: 'reserver-4',
+							account: {
+								username: 'alicebrown'
+							}
+						}
 					},
 				];
 				(
 					// biome-ignore lint/suspicious/noExplicitAny: Test mock access
 					mockDataSources.readonlyDataSource as any
 				).ReservationRequest.ReservationRequest.ReservationRequestReadRepo.getListingRequestsBySharerId.mockResolvedValue(
-					mockRequests,
+					{
+						items: mockRequests,
+						total: 4,
+						page: 1,
+						pageSize: 10,
+					},
 				);
 			});
 
@@ -87,9 +148,95 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 				},
 			);
 
-			Then('4 reservation requests should be returned', () => {
+			Then('a paginated result should be returned', () => {
 				expect(result).toBeDefined();
-				expect(result.length).toBe(4);
+				expect(result).toHaveProperty('items');
+				expect(result).toHaveProperty('total');
+				expect(result).toHaveProperty('page');
+				expect(result).toHaveProperty('pageSize');
+				expect(Array.isArray(result.items)).toBe(true);
+				expect(result.items.length).toBe(4);
+				expect(result.total).toBe(4);
+				expect(result.page).toBe(1);
+				expect(result.pageSize).toBe(10);
+
+				// Check that items are domain entities (not formatted)
+				expect(result.items[0]).toEqual({
+					id: 'req-1',
+					state: 'Requested',
+					createdAt: new Date('2024-01-01'),
+					reservationPeriodStart: new Date('2024-02-01'),
+					reservationPeriodEnd: new Date('2024-02-05'),
+					listing: {
+						id: 'listing-1',
+						title: 'Test Listing 1',
+						images: ['image1.jpg'],
+						sharer: { id: 'sharer-123' }
+					},
+					reserver: {
+						id: 'reserver-1',
+						account: {
+							username: 'johndoe'
+						}
+					}
+				});
+				expect(result.items[1]).toEqual({
+					id: 'req-2',
+					state: 'Approved',
+					createdAt: new Date('2024-01-02'),
+					reservationPeriodStart: new Date('2024-02-10'),
+					reservationPeriodEnd: new Date('2024-02-15'),
+					listing: {
+						id: 'listing-1',
+						title: 'Test Listing 1',
+						images: ['image1.jpg'],
+						sharer: { id: 'sharer-123' }
+					},
+					reserver: {
+						id: 'reserver-2',
+						account: {
+							username: 'janesmith'
+						}
+					}
+				});
+				expect(result.items[2]).toEqual({
+					id: 'req-3',
+					state: 'Requested',
+					createdAt: new Date('2024-01-03'),
+					reservationPeriodStart: new Date('2024-03-01'),
+					reservationPeriodEnd: new Date('2024-03-03'),
+					listing: {
+						id: 'listing-2',
+						title: 'Test Listing 2',
+						images: ['image2.jpg'],
+						sharer: { id: 'sharer-123' }
+					},
+					reserver: {
+						id: 'reserver-3',
+						account: {
+							username: 'bobjohnson'
+						}
+					}
+				});
+				expect(result.items[3]).toEqual({
+					id: 'req-4',
+					state: 'Rejected',
+					createdAt: new Date('2024-01-04'),
+					reservationPeriodStart: new Date('2024-03-10'),
+					reservationPeriodEnd: new Date('2024-03-12'),
+					listing: {
+						id: 'listing-2',
+						title: 'Test Listing 2',
+						images: [],
+						sharer: { id: 'sharer-123' }
+					},
+					reserver: {
+						id: 'reserver-4',
+						account: {
+							username: 'alicebrown'
+						}
+					}
+				});
 			});
 		},
 	);
@@ -106,7 +253,12 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 					// biome-ignore lint/suspicious/noExplicitAny: Test mock access
 					mockDataSources.readonlyDataSource as any
 				).ReservationRequest.ReservationRequest.ReservationRequestReadRepo.getListingRequestsBySharerId.mockResolvedValue(
-					[],
+					{
+						items: [],
+						total: 0,
+						page: 1,
+						pageSize: 10,
+					},
 				);
 			});
 
@@ -118,9 +270,17 @@ test.for(feature, ({ Scenario, BeforeEachScenario }) => {
 				},
 			);
 
-			Then('an empty array should be returned', () => {
+			Then('an empty paginated result should be returned', () => {
 				expect(result).toBeDefined();
-				expect(result.length).toBe(0);
+				expect(result).toHaveProperty('items');
+				expect(result).toHaveProperty('total');
+				expect(result).toHaveProperty('page');
+				expect(result).toHaveProperty('pageSize');
+				expect(Array.isArray(result.items)).toBe(true);
+				expect(result.items.length).toBe(0);
+				expect(result.total).toBe(0);
+				expect(result.page).toBe(1);
+				expect(result.pageSize).toBe(10);
 			});
 		},
 	);

--- a/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.ts
+++ b/packages/sthrift/application-services/src/contexts/reservation-request/reservation-request/query-listing-requests-by-sharer-id.ts
@@ -3,7 +3,11 @@ import type { DataSources } from '@sthrift/persistence';
 
 export interface ReservationRequestQueryListingRequestsBySharerIdCommand {
     sharerId: string;
-    fields?: string[];
+    page?: number;
+    pageSize?: number;
+    searchText?: string;
+    statusFilters?: string[];
+    sorter?: { field: string | null; order: 'ascend' | 'descend' | null };
 }
 
 // Temporary implementation backed by mock data in persistence read repository
@@ -12,10 +16,23 @@ export const queryListingRequestsBySharerId = (
 ) => {
     return async (
         command: ReservationRequestQueryListingRequestsBySharerIdCommand,
-    ): Promise<Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[]> => {
+    ): Promise<{
+        items: Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[];
+        total: number;
+        page: number;
+        pageSize: number;
+    }> => {
+        const options: Parameters<typeof dataSources.readonlyDataSource.ReservationRequest.ReservationRequest.ReservationRequestReadRepo.getListingRequestsBySharerId>[1] = {};
+        
+        if (command.page !== undefined) options.page = command.page;
+        if (command.pageSize !== undefined) options.pageSize = command.pageSize;
+        if (command.searchText !== undefined) options.searchText = command.searchText;
+        if (command.statusFilters !== undefined) options.statusFilters = command.statusFilters;
+        if (command.sorter !== undefined) options.sorter = command.sorter;
+
         return await dataSources.readonlyDataSource.ReservationRequest.ReservationRequest.ReservationRequestReadRepo.getListingRequestsBySharerId(
             command.sharerId,
-            { fields: command.fields }
+            options
         );
     };
 };

--- a/packages/sthrift/graphql/src/schema/types/listing/features/item-listing.resolvers.feature
+++ b/packages/sthrift/graphql/src/schema/types/listing/features/item-listing.resolvers.feature
@@ -94,13 +94,6 @@ So that I can view, filter, and create listings through the GraphQL API
 		And missing images should map image to null
 		And missing or blank states should map status to "Unknown"
 
-	Scenario: Querying adminListings with all filters
-		Given an admin user with valid credentials
-		And pagination arguments with searchText, statusFilters, and sorter
-		When the adminListings query is executed
-		Then it should call Listing.ItemListing.queryPaged with all provided parameters
-		And it should return paginated results
-
 	Scenario: Querying adminListings without any filters
 		Given an admin user with valid credentials
 		When the adminListings query is executed with only page and pageSize
@@ -124,3 +117,42 @@ So that I can view, filter, and create listings through the GraphQL API
 		When the deleteItemListing mutation is executed
 		Then it should call Listing.ItemListing.deleteListings with ID and email
 		And it should return success status
+
+	Scenario: Querying myListingsAll with sorting by title ascending
+		Given a verified user and valid pagination arguments
+		And a sorter with field "title" and order "ascend"
+		When the myListingsAll query is executed
+		Then it should call Listing.ItemListing.queryPaged with sorter field and order
+		And it should return sorted listings
+
+	Scenario: Querying myListingsAll with sorting by createdAt descending
+		Given a verified user and valid pagination arguments
+		And a sorter with field "createdAt" and order "descend"
+		When the myListingsAll query is executed
+		Then it should call Listing.ItemListing.queryPaged with sorter field and order
+
+	Scenario: Querying myListingsAll with invalid sorter order defaults to ascend
+		Given a verified user and valid pagination arguments
+		And a sorter with invalid order value
+		When the myListingsAll query is executed
+		Then it should default sorter order to "ascend"
+
+	Scenario: Querying myListingsAll with combined search, filters, and sorting
+		Given a verified user and valid pagination arguments
+		And search text "camera", status filters ["Active"], and sorter by title ascending
+		When the myListingsAll query is executed
+		Then it should call Listing.ItemListing.queryPaged with all combined parameters
+		And it should return filtered and sorted results
+
+	Scenario: Querying myListingsAll with no matching results after filtering
+		Given a verified user and strict filter criteria
+		And no listings match the search and filter criteria
+		When the myListingsAll query is executed
+		Then it should return empty results with total 0
+
+	Scenario: Querying myListingsAll with invalid sorter field
+		Given a verified user and pagination arguments
+		And a sorter with an unsupported field name
+		When the myListingsAll query is executed
+		Then it should still call Listing.ItemListing.queryPaged with the sorter parameters
+		And it should return results (field validation is handled by application service)

--- a/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
+++ b/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
@@ -2,44 +2,6 @@ import type { GraphContext } from '../../../init/context.ts';
 import type { Resolvers } from '../../builder/generated.js';
 import { PopulateUserFromField } from '../../resolver-helper.ts';
 
-// Helper type for paged arguments
-export type PagedArgs = {
-	page: number;
-	pageSize: number;
-	searchText?: string;
-	statusFilters?: string[];
-	sorter?: { field: string; order: 'ascend' | 'descend' };
-	sharerId?: string;
-};
-
-// Helper function to construct pagedArgs
-function buildPagedArgs(
-	args: {
-		page: number;
-		pageSize: number;
-		searchText?: string | null;
-		statusFilters?: readonly string[] | null;
-		sorter?: { field: string; order: string } | null;
-	},
-	extra?: Partial<PagedArgs>,
-): PagedArgs {
-  return {
-    page: args.page,
-    pageSize: args.pageSize,
-    ...(args.searchText == null ? {} : { searchText: args.searchText }),
-    ...(args.statusFilters ? { statusFilters: [...args.statusFilters] } : {}),
-    ...(args.sorter
-      ? {
-          sorter: {
-            field: args.sorter.field,
-            order: args.sorter.order as 'ascend' | 'descend',
-          },
-        }
-      : {}),
-    ...extra,
-  };
-}
-
 const itemListingResolvers: Resolvers = {
 	ItemListing: {
 		sharer: PopulateUserFromField('sharer'),
@@ -56,11 +18,25 @@ const itemListingResolvers: Resolvers = {
 					}).then((user) => (user ? user.id : undefined));
 			}
 
-			const pagedArgs = buildPagedArgs(args, sharerId ? { sharerId } : {});
+			const command: Parameters<typeof context.applicationServices.Listing.ItemListing.queryPaged>[0] = {
+				page: args.page,
+				pageSize: args.pageSize,
+				searchText: args.searchText ?? "",
+				statusFilters: [...(args.statusFilters ?? [])],
+			};
 
-			return await context.applicationServices.Listing.ItemListing.queryPaged(
-				pagedArgs,
-			);
+			if (args.sorter) {
+				command.sorter = {
+					field: args.sorter.field,
+					order: args.sorter.order === 'ascend' || args.sorter.order === 'descend' ? args.sorter.order : "ascend",
+				};
+			}
+
+			if (sharerId) {
+				command.sharerId = sharerId;
+			}
+
+			return await context.applicationServices.Listing.ItemListing.queryPaged(command);
 		},
 		itemListings: async (_parent, _args, context) => {
 			return await context.applicationServices.Listing.ItemListing.queryAll({});
@@ -73,11 +49,21 @@ const itemListingResolvers: Resolvers = {
 		},
 		adminListings: async (_parent, args, context) => {
 			// Admin-note: role-based authorization should be implemented here (security)
-			const pagedArgs = buildPagedArgs(args);
+			const command: Parameters<typeof context.applicationServices.Listing.ItemListing.queryPaged>[0] = {
+				page: args.page,
+				pageSize: args.pageSize,
+				searchText: args.searchText ?? "",
+				statusFilters: [...(args.statusFilters ?? [])],
+			};
 
-			return await context.applicationServices.Listing.ItemListing.queryPaged(
-				pagedArgs,
-			);
+			if (args.sorter) {
+				command.sorter = {
+					field: args.sorter.field,
+					order: args.sorter.order === 'ascend' || args.sorter.order === 'descend' ? args.sorter.order : "ascend",
+				};
+			}
+
+			return await context.applicationServices.Listing.ItemListing.queryPaged(command);
 		},
 	},
 	Mutation: {

--- a/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
+++ b/packages/sthrift/graphql/src/schema/types/listing/item-listing.resolvers.ts
@@ -21,8 +21,8 @@ const itemListingResolvers: Resolvers = {
 			const command: Parameters<typeof context.applicationServices.Listing.ItemListing.queryPaged>[0] = {
 				page: args.page,
 				pageSize: args.pageSize,
-				searchText: args.searchText ?? "",
-				statusFilters: [...(args.statusFilters ?? [])],
+				...(args.searchText ? { searchText: args.searchText } : {}),
+				...(args.statusFilters ? { statusFilters: [...args.statusFilters] } : {}),
 			};
 
 			if (args.sorter) {
@@ -52,8 +52,8 @@ const itemListingResolvers: Resolvers = {
 			const command: Parameters<typeof context.applicationServices.Listing.ItemListing.queryPaged>[0] = {
 				page: args.page,
 				pageSize: args.pageSize,
-				searchText: args.searchText ?? "",
-				statusFilters: [...(args.statusFilters ?? [])],
+				...(args.searchText ? { searchText: args.searchText } : {}),
+				...(args.statusFilters ? { statusFilters: [...args.statusFilters] } : {}),
 			};
 
 			if (args.sorter) {

--- a/packages/sthrift/graphql/src/schema/types/reservation-request/features/reservation-request.resolvers.feature
+++ b/packages/sthrift/graphql/src/schema/types/reservation-request/features/reservation-request.resolvers.feature
@@ -53,10 +53,10 @@ So that I can view my reservations and make new ones through the GraphQL API
     Then only listings whose titles include "camera" should be returned
 
   Scenario: Filtering myListingsRequests by status
-    Given reservation requests with mixed statuses ["Pending", "Approved"]
-    And a statusFilters ["Approved"]
+    Given reservation requests with mixed statuses ["Pending", "Accepted"]
+    And a statusFilters ["Accepted"]
     When the myListingsRequests query is executed
-    Then only requests with status "Approved" should be included
+    Then only requests with status "Accepted" should be included
 
   Scenario: Sorting myListingsRequests by requestedOn descending
     Given reservation requests with varying createdAt timestamps
@@ -126,19 +126,13 @@ So that I can view my reservations and make new ones through the GraphQL API
     When the createReservationRequest mutation is executed
     Then it should propagate the error message
 
-  Scenario: Mapping listing request fields
-    Given a ListingRequestDomainShape object with title, state, and reserver username
-    When paginateAndFilterListingRequests is called
-    Then it should map title, requestedBy, requestedOn, reservationPeriod, and status into ListingRequestUiShape
-    And missing fields should default to 'Unknown', '@unknown', or 'Pending' as appropriate
-
   Scenario: Paginating listing requests
     Given 25 listing requests and a pageSize of 10
-    When paginateAndFilterListingRequests is called for page 2
-    Then it should return 10 items starting from index 10 and total 25
+    When the myListingsRequests query is executed for page 2
+    Then it should return 10 items for page 2 and total 25
 
   Scenario: Sorting listing requests by title ascending
     Given multiple listing requests with varying titles
     And sorter field "title" with order "ascend"
-    When paginateAndFilterListingRequests is called
+    When the myListingsRequests query is executed
     Then the results should be sorted alphabetically by title

--- a/packages/sthrift/graphql/src/schema/types/reservation-request/features/reservation-request.resolvers.feature
+++ b/packages/sthrift/graphql/src/schema/types/reservation-request/features/reservation-request.resolvers.feature
@@ -136,3 +136,40 @@ So that I can view my reservations and make new ones through the GraphQL API
     And sorter field "title" with order "ascend"
     When the myListingsRequests query is executed
     Then the results should be sorted alphabetically by title
+
+  Scenario: Sorting myListingsRequests by state descending
+    Given reservation requests with different states
+    And sorter field "state" with order "descend"
+    When the myListingsRequests query is executed
+    Then results should be sorted by state in descending order
+
+  Scenario: Sorting myListingsRequests by createdAt ascending
+    Given reservation requests with different creation dates
+    And sorter field "createdAt" with order "ascend"
+    When the myListingsRequests query is executed
+    Then results should be sorted by createdAt in ascending order
+
+  Scenario: myListingsRequests with invalid sorter order defaults to null
+    Given reservation requests for a sharer
+    And a sorter with invalid order value
+    When the myListingsRequests query is executed
+    Then it should call queryListingRequestsBySharerId with sorter order set to null
+
+  Scenario: myListingsRequests with combined search, filters, and sorting
+    Given reservation requests with mixed properties
+    And search text "camera", status filters ["Accepted"], and sorter by title ascending
+    When the myListingsRequests query is executed
+    Then it should call queryListingRequestsBySharerId with all combined parameters
+    And it should return filtered and sorted results
+
+  Scenario: myListingsRequests with no matching results after filtering
+    Given reservation requests for a sharer
+    And no requests match the strict filter criteria
+    When the myListingsRequests query is executed
+    Then it should return empty results with total 0
+
+  Scenario: myListingsRequests with null sorter field
+    Given reservation requests for a sharer
+    And a sorter with null field
+    When the myListingsRequests query is executed
+    Then it should call queryListingRequestsBySharerId with sorter field set to null

--- a/packages/sthrift/graphql/src/schema/types/reservation-request/reservation-request.graphql
+++ b/packages/sthrift/graphql/src/schema/types/reservation-request/reservation-request.graphql
@@ -19,6 +19,13 @@ enum ReservationRequestState {
 	Cancelled
 }
 
+type ReservationRequestPage {
+	items: [ReservationRequest!]!
+	total: Int!
+	page: Int!
+	pageSize: Int!
+}
+
 extend type Query {
 	myActiveReservations(userId: ObjectID!): [ReservationRequest!]!
 	myPastReservations(userId: ObjectID!): [ReservationRequest!]!
@@ -29,7 +36,7 @@ extend type Query {
 		statusFilters: [String!]!
 		sorter: SorterInput!
 		sharerId: ObjectID!
-	): ListingRequestPage!
+	): ReservationRequestPage!
 	myActiveReservationForListing(
 		listingId: ObjectID!
 		userId: ObjectID!

--- a/packages/sthrift/graphql/src/schema/types/reservation-request/reservation-request.resolvers.ts
+++ b/packages/sthrift/graphql/src/schema/types/reservation-request/reservation-request.resolvers.ts
@@ -6,111 +6,6 @@ import {
 	PopulateUserFromField,
 } from '../../resolver-helper.ts';
 
-interface ListingRequestDomainShape {
-	id: string;
-	state?: string;
-	createdAt?: Date;
-	reservationPeriodStart?: Date;
-	reservationPeriodEnd?: Date;
-	listing?: { title?: string; [k: string]: unknown };
-	reserver?: { account?: { username?: string } };
-	[k: string]: unknown; // allow passthrough
-}
-
-interface ListingRequestUiShape {
-	id: string;
-	title: string;
-	image: string;
-	requestedBy: string;
-	requestedOn: string;
-	reservationPeriod: string;
-	status: string;
-	_raw: ListingRequestDomainShape;
-	[k: string]: unknown; // enable dynamic field sorting access
-}
-
-function paginateAndFilterListingRequests(
-	requests: ListingRequestDomainShape[],
-	options: {
-		page: number;
-		pageSize: number;
-		searchText?: string;
-		statusFilters: string[];
-		sorter?: { field: string | null; order: 'ascend' | 'descend' | null };
-	},
-) {
-	const filtered = [...requests];
-
-	// Map domain objects into shape expected by client (flatten minimal fields)
-	const mapped: ListingRequestUiShape[] = filtered.map((r) => {
-		const start =
-			r.reservationPeriodStart instanceof Date
-				? r.reservationPeriodStart
-				: undefined;
-		const end =
-			r.reservationPeriodEnd instanceof Date
-				? r.reservationPeriodEnd
-				: undefined;
-		return {
-			id: r.id,
-			title: r.listing?.title ?? 'Unknown',
-			image: '/assets/item-images/placeholder.png', // TODO: map real image when available
-			requestedBy: r.reserver?.account?.username
-				? `@${r.reserver.account.username}`
-				: '@unknown',
-			requestedOn:
-				r.createdAt instanceof Date
-					? r.createdAt.toISOString()
-					: new Date().toISOString(),
-			reservationPeriod: `${start ? start.toISOString().slice(0, 10) : 'N/A'} - ${end ? end.toISOString().slice(0, 10) : 'N/A'}`,
-			status: r.state ?? 'Pending',
-			_raw: r,
-		};
-	});
-
-	let working = mapped;
-	if (options.searchText) {
-		const term = options.searchText.toLowerCase();
-		working = working.filter((m) => m.title.toLowerCase().includes(term));
-	}
-
-	if (options.statusFilters?.length) {
-		working = working.filter((m) => options.statusFilters?.includes(m.status));
-	}
-
-	if (options.sorter?.field) {
-		const { field, order } = options.sorter;
-		working.sort((a: ListingRequestUiShape, b: ListingRequestUiShape) => {
-			const sortField = field as keyof ListingRequestUiShape;
-			const A = a[sortField];
-			const B = b[sortField];
-			if (A == null) {
-				return order === 'ascend' ? -1 : 1;
-			}
-			if (B == null) {
-				return order === 'ascend' ? 1 : -1;
-			}
-			if (A < B) {
-				return order === 'ascend' ? -1 : 1;
-			}
-			if (A > B) {
-				return order === 'ascend' ? 1 : -1;
-			}
-			return 0;
-		});
-	}
-
-	const total = working.length;
-	const startIndex = (options.page - 1) * options.pageSize;
-	const endIndex = startIndex + options.pageSize;
-	return {
-		items: working.slice(startIndex, endIndex),
-		total,
-		page: options.page,
-		pageSize: options.pageSize,
-	};
-}
-
 const reservationRequest: Resolvers = {
 	ReservationRequest: {
 		reserver: PopulateUserFromField('reserver'),
@@ -147,21 +42,23 @@ const reservationRequest: Resolvers = {
 			context: GraphContext,
 		) => {
 			// Fetch reservation requests for listings owned by sharer from application services
-			const requests =
-				await context.applicationServices.ReservationRequest.ReservationRequest.queryListingRequestsBySharerId(
-					{
-						sharerId: args.sharerId,
-					},
-				);
-			return paginateAndFilterListingRequests(
-				requests as unknown as ListingRequestDomainShape[],
-				{
-					page: args.page,
-					pageSize: args.pageSize,
-					searchText: args.searchText,
-					statusFilters: [...(args.statusFilters ?? [])],
-				},
-			);
+			const command: Parameters<typeof context.applicationServices.ReservationRequest.ReservationRequest.queryListingRequestsBySharerId>[0] = {
+				sharerId: args.sharerId,
+				page: args.page,
+				pageSize: args.pageSize,
+				searchText: args.searchText,
+				statusFilters: [...(args.statusFilters ?? [])],
+			};
+
+			if (args.sorter) {
+				command.sorter = {
+					field: args.sorter.field || null,
+					order: args.sorter.order === 'ascend' || args.sorter.order === 'descend' ? args.sorter.order : null,
+				};
+			}
+
+			return await context.applicationServices.ReservationRequest.ReservationRequest.queryListingRequestsBySharerId(command);
+
 		},
 		myActiveReservationForListing: async (
 			_parent,

--- a/packages/sthrift/persistence/src/datasources/messaging/conversation/conversation/messaging-conversation.domain-adapter.ts
+++ b/packages/sthrift/persistence/src/datasources/messaging/conversation/conversation/messaging-conversation.domain-adapter.ts
@@ -4,13 +4,11 @@ import { Domain } from '@sthrift/domain';
 export function toDomainMessage(
 	messagingMessage: MessageInstance,
 	authorId: Domain.Contexts.Conversation.Conversation.AuthorId,
-): Domain.Contexts.Conversation.Conversation.MessageEntityReference {
-	// biome-ignore lint/complexity/useLiteralKeys: metadata is an index signature requiring bracket notation
-	const messagingId =
-		(messagingMessage.metadata?.['originalSid'] as string) ||
-		messagingMessage.id;
-
-	const messagingMessageId =
+	): Domain.Contexts.Conversation.Conversation.MessageEntityReference {
+		const messagingId =
+			// biome-ignore lint/complexity/useLiteralKeys: metadata key contains uppercase letter, not valid JS identifier
+			(messagingMessage.metadata?.['originalSid'] as string) ||
+			messagingMessage.id;	const messagingMessageId =
 		new Domain.Contexts.Conversation.Conversation.MessagingMessageId(
 			messagingId,
 		);

--- a/packages/sthrift/persistence/src/datasources/readonly/conversation/conversation/conversation.read-repository.test.ts
+++ b/packages/sthrift/persistence/src/datasources/readonly/conversation/conversation/conversation.read-repository.test.ts
@@ -145,10 +145,6 @@ test.for(feature, ({ Scenario, Background, BeforeEachScenario }) => {
 			mockQuery.lean.mockReturnValue(mockQuery);
 			mockQuery.populate.mockReturnValue(mockQuery);
 			
-			// SONARQUBE SUPPRESSION: S7739 - Intentional thenable mock
-			// This object intentionally implements the 'then' property to mock Mongoose
-			// query behavior. Mongoose queries are thenable and can be awaited.
-			// biome-ignore lint/suspicious/noThenProperty: Intentional thenable mock for Mongoose queries
 			Object.defineProperty(mockQuery, 'then', {
 				value: vi.fn((onResolve) => Promise.resolve(result).then(onResolve)),
 				enumerable: false,

--- a/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/features/reservation-request.read-repository.feature
+++ b/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/features/reservation-request.read-repository.feature
@@ -41,8 +41,8 @@ And valid ReservationRequest documents exist in the database
 	Scenario: Getting listing requests by sharer ID
 		Given a ReservationRequest document with listing owned by "sharer-1"
 		When I call getListingRequestsBySharerId with "sharer-1"
-		Then I should receive an array of ReservationRequest entities
-		And the array should contain reservation requests for listings owned by "sharer-1"
+		Then I should receive a paginated result with items
+		And the items array should contain reservation requests for listings owned by "sharer-1"
 
 	Scenario: Getting active reservation by reserver ID and listing ID
 		Given a ReservationRequest document with reserver "user-1", listing "listing-1", and state "Accepted"

--- a/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/features/reservation-request.read-repository.feature
+++ b/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/features/reservation-request.read-repository.feature
@@ -44,6 +44,30 @@ And valid ReservationRequest documents exist in the database
 		Then I should receive a paginated result with items
 		And the items array should contain reservation requests for listings owned by "sharer-1"
 
+	Scenario: Getting listing requests by sharer ID with pagination
+		Given multiple ReservationRequest documents for listings owned by "sharer-1"
+		When I call getListingRequestsBySharerId with "sharer-1", page 2, and pageSize 2
+		Then I should receive a paginated result with page 2 and pageSize 2
+		And the items array should contain 2 reservation requests
+
+	Scenario: Getting listing requests by sharer ID with search
+		Given ReservationRequest documents with different listing titles
+		When I call getListingRequestsBySharerId with "sharer-1" and searchText "camera"
+		Then I should receive a paginated result with items
+		And only items with listing titles containing "camera" should be included
+
+	Scenario: Getting listing requests by sharer ID with status filters
+		Given ReservationRequest documents with different states
+		When I call getListingRequestsBySharerId with "sharer-1" and statusFilters ["Approved"]
+		Then I should receive a paginated result with items
+		And only items with state "Approved" should be included
+
+	Scenario: Getting listing requests by sharer ID with sorting
+		Given ReservationRequest documents with different createdAt dates
+		When I call getListingRequestsBySharerId with "sharer-1" and sorter field "createdAt" order "descend"
+		Then I should receive a paginated result with items
+		And the items should be sorted by createdAt in descending order
+
 	Scenario: Getting active reservation by reserver ID and listing ID
 		Given a ReservationRequest document with reserver "user-1", listing "listing-1", and state "Accepted"
 		When I call getActiveByReserverIdAndListingId with "user-1" and "listing-1"

--- a/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/reservation-request.read-repository.test.ts
+++ b/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/reservation-request.read-repository.test.ts
@@ -387,15 +387,42 @@ test.for(feature, ({ Scenario, Background, BeforeEachScenario }) => {
 					createValidObjectId('sharer-1'),
 				);
 			});
-			Then('I should receive an array of ReservationRequest entities', () => {
-				expect(Array.isArray(result)).toBe(true);
+			Then('I should receive a paginated result with items', () => {
+				const paginatedResult = result as {
+					items: unknown[];
+					total: number;
+					page: number;
+					pageSize: number;
+				};
+				expect(paginatedResult).toHaveProperty('items');
+				expect(paginatedResult).toHaveProperty('total');
+				expect(paginatedResult).toHaveProperty('page');
+				expect(paginatedResult).toHaveProperty('pageSize');
+				expect(Array.isArray(paginatedResult.items)).toBe(true);
 			});
 			And(
-				'the array should contain reservation requests for listings owned by "sharer-1"',
+				'the result should contain formatted listing request data',
 				() => {
-					const reservations =
-						result as Domain.Contexts.ReservationRequest.ReservationRequest.ReservationRequestEntityReference[];
-					expect(reservations.length).toBeGreaterThan(0);
+					const paginatedResult = result as {
+						items: {
+							id: string;
+							title: string;
+							image: string;
+							requestedBy: string;
+							requestedOn: string;
+							reservationPeriod: string;
+							status: string;
+						}[];
+					};
+					expect(paginatedResult.items.length).toBeGreaterThan(0);
+					const firstItem = paginatedResult.items[0];
+					expect(firstItem).toHaveProperty('id');
+					expect(firstItem).toHaveProperty('title');
+					expect(firstItem).toHaveProperty('image');
+					expect(firstItem).toHaveProperty('requestedBy');
+					expect(firstItem).toHaveProperty('requestedOn');
+					expect(firstItem).toHaveProperty('reservationPeriod');
+					expect(firstItem).toHaveProperty('status');
 				},
 			);
 		},

--- a/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/reservation-request.read-repository.ts
+++ b/packages/sthrift/persistence/src/datasources/readonly/reservation-request/reservation-request/reservation-request.read-repository.ts
@@ -299,11 +299,10 @@ export class ReservationRequestReadRepositoryImpl
 				let sortField = options.sorter.field;
 				if (sortField === 'requestedOn') sortField = 'createdAt';
 				sortOptions[sortField] = sortOrder;
-			} else {
-				sortOptions['createdAt'] = -1;
-			}
-
-			// Get total count
+						} else {
+							// biome-ignore lint/complexity/useLiteralKeys: Index signature requires bracket notation
+							sortOptions['createdAt'] = -1;
+						}			// Get total count
 			const total = await this.models.ReservationRequest.ReservationRequest.countDocuments(filter).exec();
 
 			// Get paginated results with population

--- a/packages/sthrift/persistence/src/datasources/readonly/user/admin-user/admin-user.read-repository.test.ts
+++ b/packages/sthrift/persistence/src/datasources/readonly/user/admin-user/admin-user.read-repository.test.ts
@@ -159,8 +159,8 @@ test.for(feature, ({ Scenario, Background, BeforeEachScenario }) => {
 	});
 
 	Scenario('Getting all admin users with no results', ({ Given, When, Then }) => {
-		Given('no AdminUser documents exist in the database', () => {
-			const mockDataSource = repository['mongoDataSource'] as unknown as {
+					Given('no AdminUser documents exist in the database', () => {
+						const mockDataSource = repository.mongoDataSource as unknown as {
 				find: ReturnType<typeof vi.fn>;
 			};
 			mockDataSource.find = vi.fn(() => Promise.resolve([]));

--- a/packages/sthrift/persistence/src/datasources/readonly/user/personal-user/personal-user.read-repository.test.ts
+++ b/packages/sthrift/persistence/src/datasources/readonly/user/personal-user/personal-user.read-repository.test.ts
@@ -149,8 +149,8 @@ test.for(feature, ({ Scenario, Background, BeforeEachScenario }) => {
 	});
 
 	Scenario('Getting all personal users with no results', ({ Given, When, Then }) => {
-		Given('no PersonalUser documents exist in the database', () => {
-			const mockDataSource = repository['mongoDataSource'] as unknown as {
+					Given('no PersonalUser documents exist in the database', () => {
+						const mockDataSource = repository.mongoDataSource as unknown as {
 				find: ReturnType<typeof vi.fn>;
 			};
 			mockDataSource.find = vi.fn(() => Promise.resolve([]));

--- a/packages/sthrift/ui-components/package.json
+++ b/packages/sthrift/ui-components/package.json
@@ -53,7 +53,7 @@
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
 		"react-oidc-context": "^3.3.0",
-		"react-router-dom": "^7.8.2",
+		"react-router-dom": "^7.12.0",
 		"rxjs": "^7.8.2"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ catalogs:
 
 overrides:
   node-forge@<1.3.2: '>=1.3.2'
+  '@pnpm/npm-conf': ^3.0.2
 
 importers:
 
@@ -4396,8 +4397,8 @@ packages:
     resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
     engines: {node: '>=12.22.0'}
 
-  '@pnpm/npm-conf@2.3.1':
-    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
+  '@pnpm/npm-conf@3.0.2':
+    resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
   '@polka/url@1.0.0-next.29':
@@ -16250,7 +16251,7 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.10
 
-  '@pnpm/npm-conf@2.3.1':
+  '@pnpm/npm-conf@3.0.2':
     dependencies:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
@@ -23528,7 +23529,7 @@ snapshots:
 
   registry-auth-token@5.1.0:
     dependencies:
-      '@pnpm/npm-conf': 2.3.1
+      '@pnpm/npm-conf': 3.0.2
 
   registry-url@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.3.0)(react@19.2.0)
       react-router-dom:
-        specifier: ^7.8.0
-        version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -322,7 +322,7 @@ importers:
         version: 9.1.17(@types/react@19.2.2)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))
       '@storybook/addon-vitest':
         specifier: ^9.1.17
-        version: 9.1.17(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(vitest@4.0.15)
+        version: 9.1.17(@vitest/browser-playwright@4.0.15(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4))(@vitest/browser@3.2.4)(@vitest/runner@4.0.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(vitest@3.2.4)
       '@storybook/react':
         specifier: ^9.1.17
         version: 9.1.17(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.8.3)
@@ -344,9 +344,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/browser':
+        specifier: 3.2.4
+        version: 3.2.4(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
       '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 4.0.15(@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15))(vitest@4.0.15)
+        specifier: ^3.2.4
+        version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       eslint:
         specifier: ^9.30.1
         version: 9.38.0(jiti@2.6.1)
@@ -369,11 +372,11 @@ importers:
         specifier: ^8.35.1
         version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.8.3)
       vite:
-        specifier: 'catalog:'
+        specifier: ^7.1.2
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
-        specifier: 'catalog:'
-        version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/cellix/api-services-spec:
     devDependencies:
@@ -645,8 +648,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.3.0)(react@19.2.0)
       react-router-dom:
-        specifier: ^7.9.3
-        version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1304,8 +1307,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0(oidc-client-ts@3.3.0)(react@19.2.0)
       react-router-dom:
-        specifier: ^7.8.2
-        version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.12.0
+        version: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -1454,6 +1457,10 @@ packages:
     hasBin: true
     peerDependencies:
       vitest: ^4.0.4
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -3815,6 +3822,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5269,10 +5280,34 @@ packages:
       playwright: '*'
       vitest: 4.0.15
 
+  '@vitest/browser@3.2.4':
+    resolution: {integrity: sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==}
+    peerDependencies:
+      playwright: '*'
+      safaridriver: '*'
+      vitest: 3.2.4
+      webdriverio: ^7.0.0 || ^8.0.0 || ^9.0.0
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+
   '@vitest/browser@4.0.15':
     resolution: {integrity: sha512-zedtczX688KehaIaAv7m25CeDLb0gBtAOa2Oi1G1cqvSO5aLSVfH6lpZMJLW8BKYuWMxLQc9/5GYoM+jgvGIrw==}
     peerDependencies:
       vitest: 4.0.15
+
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/coverage-v8@4.0.15':
     resolution: {integrity: sha512-FUJ+1RkpTFW7rQITdgTi93qOCWJobWhBirEPCeXh2SW2wsTlFxy51apDz5gzG+ZEYt/THvWeNmhdAoS9DTwpCw==}
@@ -5317,8 +5352,14 @@ packages:
   '@vitest/pretty-format@4.0.15':
     resolution: {integrity: sha512-SWdqR8vEv83WtZcrfLNqlqeQXlQLh2iilO1Wk1gv4eiHKjEzvgHb2OVc3mIPyhZE6F+CtfYjNlDJwP5MN6Km7A==}
 
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
   '@vitest/runner@4.0.15':
     resolution: {integrity: sha512-+A+yMY8dGixUhHmNdPUxOh0la6uVzun86vAbuMT3hIDxMrAOmn5ILBHm8ajrqHE0t8R9T1dGnde1A5DTnmi3qw==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/snapshot@4.0.15':
     resolution: {integrity: sha512-A7Ob8EdFZJIBjLjeO0DZF4lqR6U7Ydi5/5LIZ0xcI+23lYlsYJAfGn8PrIWTYdZQRNnSRlzhg0zyGu37mVdy5g==}
@@ -5877,6 +5918,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -8473,6 +8518,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
   magicast@0.5.1:
     resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
@@ -10196,8 +10244,8 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router-dom@7.9.5:
-    resolution: {integrity: sha512-mkEmq/K8tKN63Ae2M7Xgz3c9l9YNbY+NHH6NNeUmLA3kDkhKXRsNb/ZpxaEunvGo2/3YXdk5EJU3Hxp3ocaBPw==}
+  react-router-dom@7.12.0:
+    resolution: {integrity: sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -10208,8 +10256,8 @@ packages:
     peerDependencies:
       react: '>=15'
 
-  react-router@7.9.5:
-    resolution: {integrity: sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==}
+  react-router@7.12.0:
+    resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -10996,6 +11044,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strip-outer@1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
@@ -11092,6 +11143,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
+
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -11140,6 +11195,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -11641,6 +11699,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11679,6 +11742,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.0.15:
@@ -12153,6 +12244,11 @@ snapshots:
       parsecurrency: 1.1.1
       ts-morph: 26.0.0
       vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@ant-design/colors@7.2.1':
     dependencies:
@@ -15525,6 +15621,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -16531,6 +16629,22 @@ snapshots:
     dependencies:
       storybook: 9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
 
+  '@storybook/addon-vitest@9.1.17(@vitest/browser-playwright@4.0.15(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4))(@vitest/browser@3.2.4)(@vitest/runner@4.0.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(vitest@3.2.4)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      prompts: 2.4.2
+      storybook: 9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
+      '@vitest/browser-playwright': 4.0.15(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
+      '@vitest/runner': 4.0.15
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/addon-vitest@9.1.17(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(vitest@4.0.15)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -17177,6 +17291,20 @@ snapshots:
       - vite
     optional: true
 
+  '@vitest/browser-playwright@4.0.15(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)':
+    dependencies:
+      '@vitest/browser': 4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
+      '@vitest/mocker': 4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      playwright: 1.56.1
+      tinyrainbow: 3.0.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.0.15(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15)':
     dependencies:
       '@vitest/browser': 4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15)
@@ -17184,6 +17312,25 @@ snapshots:
       playwright: 1.56.1
       tinyrainbow: 3.0.3
       vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@3.2.4(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.21
+      sirv: 3.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      ws: 8.18.3
+    optionalDependencies:
+      playwright: 1.56.1
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -17208,6 +17355,24 @@ snapshots:
       - vite
     optional: true
 
+  '@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)':
+    dependencies:
+      '@vitest/mocker': 4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/utils': 4.0.15
+      magic-string: 0.30.21
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.0.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15)':
     dependencies:
       '@vitest/mocker': 4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
@@ -17224,6 +17389,27 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.8
+      debug: 4.4.3(supports-color@8.1.1)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    optionalDependencies:
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@4.0.15(@vitest/browser@4.0.15(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.15))(vitest@4.0.15)':
     dependencies:
@@ -17293,9 +17479,21 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.0.15':
     dependencies:
       '@vitest/utils': 4.0.15
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.15':
@@ -18039,6 +18237,8 @@ snapshots:
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   cacheable-lookup@7.0.0: {}
 
@@ -21006,6 +21206,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
   magicast@0.5.1:
     dependencies:
       '@babel/parser': 7.28.5
@@ -23164,11 +23370,11 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router-dom@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router-dom@7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-router: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-router: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   react-router@5.3.4(react@19.2.0):
     dependencies:
@@ -23183,7 +23389,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.0.2
       react: 19.2.0
@@ -24121,6 +24327,10 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strip-outer@1.0.1:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -24247,6 +24457,12 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 9.0.5
+
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.7.3
@@ -24284,6 +24500,8 @@ snapshots:
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
 
@@ -24775,6 +24993,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.27.2
@@ -24808,6 +25047,50 @@ snapshots:
       terser: 5.44.0
       tsx: 4.20.6
       yaml: 2.8.1
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.10.4
+      '@vitest/browser': 3.2.4(playwright@1.56.1)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vitest@3.2.4)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,4 @@ catalog:
 
 overrides:
   node-forge@<1.3.2: '>=1.3.2'
+  '@pnpm/npm-conf': '^3.0.2'


### PR DESCRIPTION
## Summary by Sourcery

Update reservation request listing APIs, GraphQL schema, and UI to return and consume fully paginated ReservationRequest entities instead of custom ListingRequest shapes, adding support for server-side search, filtering, and sorting, and extend listing query resolvers and tests accordingly.

New Features:
- Introduce a paginated ReservationRequestPage GraphQL type and myListingsRequests query that work directly with ReservationRequest entities, including listing, reserver, and reservation period fields.
- Add support for combined pagination, search text, status filters, and flexible sorter parameters when querying listing reservation requests by sharer ID across persistence, application services, and GraphQL resolvers.
- Enhance the myListingsAll listing query to accept and forward search, filter, and sorting options, including sharer scoping, to the underlying application service.

Bug Fixes:
- Fix myListingsRequests data flow so that reservation requests are retrieved and returned in the correct shape from persistence through application services to GraphQL and the UI.
- Correct organization and typing of reservation-request resolvers and tests, including aligning status/state fields and fixing sorter order handling.

Enhancements:
- Refactor ReservationRequest read repository to return paginated results and to support optional search, status filtering, and sorting semantics at the database level.
- Refine GraphQL item listing resolvers by inlining command construction instead of using a generic buildPagedArgs helper, and tightening sorter order handling.
- Improve the UI requests table container to map ReservationRequest GraphQL results into the table view model, with explicit handling of missing titles, usernames, dates, and images.
- Expand unit, integration, and feature tests for reservation requests, listing queries, and read repositories to cover pagination, search, filter, and sorting combinations and edge cases.
- Add Storybook stories to validate edge cases, date formatting, and interaction scenarios (search, state filtering, and sorting) for the My Listings Requests table.

Build:
- Update UI app test coverage script name and bump Vite, Vitest, coverage, and React Router DOM versions across UI packages.

Tests:
- Broaden tests for ReservationRequest GraphQL resolvers, application service queryListingRequestsBySharerId, and the ReservationRequest read repository to assert paginated results, search, filters, and sorting behavior.
- Extend listing GraphQL resolver tests to cover myListingsAll sorting, combined filters, and invalid sorter handling.
- Add Storybook interaction tests verifying data mapping fallbacks, date formatting, state filtering, and sorting in the My Listings requests table.
- Adjust existing tests to the new paginated ReservationRequestPage shape and to the updated ReservationRequest read repository API.

Chores:
- Normalize React Router DOM version ranges across UI-related packages and clean up a few internal test utilities and mocks.