### PR TITLE
Jason/sthrift arch

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "@serenity-js/core": "^3.36.1",
         "@serenity-js/cucumber": "^3.36.1",
         "@serenity-js/serenity-bdd": "^3.36.1",
-        "@sonar/scan": "^4.3.0",
+        "@sonar/scan": "4.3.5",
         "@types/node": "^24.7.2",
         "@vitest/browser-playwright": "catalog:",
         "@vitest/coverage-v8": "catalog:",

--- a/packages/cellix/arch-unit-tests/src/checks/member-ordering.ts
+++ b/packages/cellix/arch-unit-tests/src/checks/member-ordering.ts
@@ -1,8 +1,14 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
 import { projectFiles, type FileInfo } from 'archunit';
 import { checkMemberOrdering as checkMemberOrderingRule } from '../utils/member-ordering-rule.js';
 
 export interface MemberOrderingConfig {
   sourceGlobs: string[];  // e.g. ['../sthrift/domain/src/**/*.ts']
+}
+
+function isGlobPattern(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern);
 }
 
 /**
@@ -17,7 +23,26 @@ export async function checkMemberOrdering(config: MemberOrderingConfig): Promise
 
   // Use archunit to find all matching files and check them
   for (const glob of config.sourceGlobs) {
-    await projectFiles()
+    if (!isGlobPattern(glob)) {
+      const content = await readFile(glob, 'utf8');
+      const parsedPath = path.parse(glob);
+      const result = checkMemberOrderingRule({
+        path: glob,
+        name: parsedPath.name,
+        extension: parsedPath.ext.replace(/^\./, ''),
+        directory: parsedPath.dir,
+        content,
+        linesOfCode: content.split('\n').length,
+      });
+
+      if (result !== true) {
+        allViolations.push(...result);
+      }
+
+      continue;
+    }
+
+    const archUnitViolations = await projectFiles()
       .inPath(glob)
       .should()
       .adhereTo((file: FileInfo) => {
@@ -29,6 +54,14 @@ export async function checkMemberOrdering(config: MemberOrderingConfig): Promise
         return true;
       }, 'Class members must follow proper ordering')
       .check();
+
+    for (const violation of archUnitViolations) {
+      if (typeof violation === 'object' && violation !== null && 'message' in violation) {
+        allViolations.push(String(violation.message));
+      } else {
+        allViolations.push(JSON.stringify(violation));
+      }
+    }
   }
 
   return allViolations;

--- a/packages/cellix/arch-unit-tests/src/test-suites/member-ordering.ts
+++ b/packages/cellix/arch-unit-tests/src/test-suites/member-ordering.ts
@@ -5,7 +5,6 @@ export interface MemberOrderingTestsConfig {
   domainSourcePath: string;
   persistenceSourcePath: string;
   graphqlSourcePath: string;
-  fixturesSourcePath?: string;
 }
 
 export function describeMemberOrderingTests(config: MemberOrderingTestsConfig): void {
@@ -59,7 +58,7 @@ export function describeMemberOrderingTests(config: MemberOrderingTestsConfig): 
       it('allows mixing instance methods and accessors within the same instance-member group', async () => {
         const violations = await checkMemberOrdering({
           sourceGlobs: [
-            '../../cellix/arch-unit-tests/src/fixtures/member-ordering/instance-mixed-ok.ts',
+            '../../cellix/arch-unit-tests/src/fixtures/domain-conventions/instance-mixed-ok.ts',
           ],
         });
 

--- a/packages/sthrift-verification/arch-unit-tests/README.md
+++ b/packages/sthrift-verification/arch-unit-tests/README.md
@@ -1,0 +1,40 @@
+# @sthrift-verification/arch-unit-tests
+
+This package provides ShareThrift-specific architectural enforcements that sit alongside the shared Cellix arch-unit test suites.
+
+Usage
+
+- Import the ShareThrift suites from the matching subpath, next to the Cellix suite you already run. Example:
+
+  import {
+    describeApplicationServicesConventionTests as describeShareThriftApplicationServicesConventionTests,
+    type ApplicationServicesConventionTestsConfig,
+  } from '@sthrift-verification/arch-unit-tests/application-services';
+
+  const config: ApplicationServicesConventionTestsConfig = {
+    applicationServicesGlob: '../application-services/src/contexts/**',
+    applicationServicesAllGlob: '../application-services/src/**',
+  };
+
+  describeShareThriftApplicationServicesConventionTests(config);
+
+How to add new rules
+
+- This package follows the same subpath pattern as `@cellix/arch-unit-tests`. To add ShareThrift-specific enforcements:
+  1. Add new helper/check functions in a new module under src (e.g. src/checks/*).
+  2. Create a test-suite wrapper (e.g. src/test-suites/*) that composes the Cellix test suites and your new checks.
+  3. Export the new check and test suite from the appropriate subpath module.
+  4. Update package.json exports if you add new subpaths.
+
+Running the tests
+
+- From the repo root you can run the package tests via pnpm:
+
+  pnpm --filter @sthrift-verification/arch-unit-tests test
+
+CI
+
+- Add a CI job/step to run the package tests if you want them executed standalone. Example:
+
+  - script: pnpm --filter @sthrift-verification/arch-unit-tests test
+    displayName: Run ShareThrift arch-unit-tests

--- a/packages/sthrift-verification/arch-unit-tests/package.json
+++ b/packages/sthrift-verification/arch-unit-tests/package.json
@@ -4,6 +4,15 @@
   "description": "Architectural fitness tests for ShareThrift application",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./application-services": "./src/application-services.ts",
+    "./data-sources-mongoose-models": "./src/data-sources-mongoose-models.ts",
+    "./domain": "./src/domain.ts",
+    "./frontend": "./src/frontend.ts",
+    "./graphql": "./src/graphql.ts",
+    "./persistence": "./src/persistence.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "test:arch": "vitest run",

--- a/packages/sthrift-verification/arch-unit-tests/src/application-services.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/application-services.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	checkShareThriftApplicationServicesFactoryExports,
+} from './checks/application-services-conventions.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift application-services checks', () => {
+	it('enforces entity index factory names from the folder name', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(
+			workspace,
+			'contexts/listing/item/index.ts',
+			'export const ItemListing = () => ({ queryAll: async () => [] });\n',
+		);
+		writeFile(
+			workspace,
+			'contexts/user/personal-user/index.ts',
+			[
+				'export interface PersonalUserApplicationService {',
+				'\tqueryById: () => Promise<null>;',
+				'}',
+				'export const WrongFactory = () => ({ queryById: async () => null });',
+			].join('\n'),
+		);
+
+		const violations =
+			await checkShareThriftApplicationServicesFactoryExports({
+				applicationServicesGlob: `${workspace}/contexts/**`,
+			});
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toContain('PersonalUser');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/application-services.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/application-services.ts
@@ -1,0 +1,8 @@
+export {
+	checkShareThriftApplicationServicesFactoryExports,
+} from './checks/application-services-conventions.js';
+
+export {
+	describeApplicationServicesConventionTests,
+	type ApplicationServicesConventionTestsConfig,
+} from './test-suites/application-services-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/application-services-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/application-services-conventions.ts
@@ -1,0 +1,38 @@
+import {
+	getFilesMatching,
+	getRelativeSegmentsAfter,
+	readFile,
+} from '../utils/source-files.js';
+
+export async function checkShareThriftApplicationServicesFactoryExports(
+	config: { applicationServicesGlob: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+
+	for (const filePath of getFilesMatching(config.applicationServicesGlob, 'index.ts')) {
+		const segments = getRelativeSegmentsAfter(filePath, '/contexts/');
+		if (segments.length !== 3) {
+			continue;
+		}
+
+		const content = readFile(filePath);
+		const interfaceMatch = content.match(
+			/export\s+interface\s+(\w+)ApplicationService\b/,
+		);
+		if (!interfaceMatch) {
+			continue;
+		}
+
+		const expectedFactoryName = interfaceMatch[1]!;
+		const exportPattern = new RegExp(
+			`export\\s+const\\s+${expectedFactoryName}\\s*=\\s*\\(`,
+		);
+		if (!exportPattern.test(content)) {
+			violations.push(
+				`[${filePath}] Entity application-service index must export const ${expectedFactoryName}`,
+			);
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/data-sources-mongoose-models-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/data-sources-mongoose-models-conventions.ts
@@ -1,0 +1,34 @@
+import * as path from 'node:path';
+import {
+	getFilesMatching,
+	readFile,
+	toPascalCase,
+} from '../utils/source-files.js';
+
+export async function checkShareThriftModelExportNaming(
+	config: { modelsGlob: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+
+	for (const filePath of getFilesMatching(config.modelsGlob, '.model.ts')) {
+		const fileName = path.basename(filePath, '.model.ts');
+		const modelName = toPascalCase(fileName);
+		const content = readFile(filePath);
+
+		const expectedExports = [
+			`${modelName}ModelFactory`,
+			`${modelName}ModelType`,
+			`${modelName}ModelName`,
+		];
+
+		for (const expectedExport of expectedExports) {
+			if (!content.includes(expectedExport)) {
+				violations.push(
+					`[${filePath}] Model file must export ${expectedExport} to match ${fileName}.model.ts`,
+				);
+			}
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/domain-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/domain-conventions.ts
@@ -1,0 +1,36 @@
+import * as path from 'node:path';
+import {
+	fileExists,
+	getImmediateDirectories,
+	resolveSearchRoot,
+} from '../utils/source-files.js';
+
+export async function checkShareThriftDomainContextAuthorizationFiles(
+	config: { domainContextsGlob: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+	const contextsRoot = resolveSearchRoot(config.domainContextsGlob);
+
+	for (const contextDirectory of getImmediateDirectories(contextsRoot)) {
+		if (!fileExists(path.join(contextDirectory, 'index.ts'))) {
+			continue;
+		}
+
+		const contextName = path.basename(contextDirectory);
+		const requiredFiles = [
+			`${contextName}.passport.ts`,
+			`${contextName}.domain-permissions.ts`,
+			`${contextName}.visa.ts`,
+		];
+
+		for (const requiredFile of requiredFiles) {
+			if (!fileExists(path.join(contextDirectory, requiredFile))) {
+				violations.push(
+					`[${contextDirectory}] Context must define ${requiredFile}`,
+				);
+			}
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/frontend-architecture.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/frontend-architecture.ts
@@ -1,0 +1,79 @@
+import * as path from 'node:path';
+import {
+	fileExists,
+	getAllFiles,
+	resolveSearchRoot,
+	toPosixPath,
+} from '../utils/source-files.js';
+
+export async function checkShareThriftPageStoryCoverage(
+	config: { uiSourcePath: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+	const sourceRoot = resolveSearchRoot(config.uiSourcePath);
+
+	for (const filePath of getAllFiles(sourceRoot)) {
+		const normalizedPath = toPosixPath(filePath);
+		if (
+			!normalizedPath.endsWith('.tsx') ||
+			normalizedPath.endsWith('.stories.tsx') ||
+			!normalizedPath.includes('/components/pages/') ||
+			!/\/pages\/[^/]+\.tsx$/.test(normalizedPath)
+		) {
+			continue;
+		}
+
+		const storyPath = filePath.replace(/\.tsx$/, '.stories.tsx');
+		if (!fileExists(storyPath)) {
+			violations.push(
+				`[${filePath}] Page component must have a sibling .stories.tsx file`,
+			);
+		}
+	}
+
+	return violations;
+}
+
+export async function checkShareThriftContainerPlacement(
+	config: { uiSourcePath: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+	const sourceRoot = resolveSearchRoot(config.uiSourcePath);
+
+	for (const filePath of getAllFiles(sourceRoot)) {
+		const normalizedPath = toPosixPath(filePath);
+		if (!normalizedPath.endsWith('.container.tsx')) {
+			continue;
+		}
+
+		if (!normalizedPath.includes('/components/')) {
+			violations.push(
+				`[${filePath}] Container component must live in a components/ directory`,
+			);
+		}
+	}
+
+	return violations;
+}
+
+export async function checkShareThriftContainerGraphqlPairing(
+	config: { uiSourcePath?: string } = {},
+): Promise<string[]> {
+	const violations: string[] = [];
+	const sourceRoot = resolveSearchRoot(config.uiSourcePath ?? './src');
+
+	for (const filePath of getAllFiles(sourceRoot)) {
+		if (!filePath.endsWith('.container.graphql')) {
+			continue;
+		}
+
+		const componentPath = filePath.replace(/\.container\.graphql$/, '.container.tsx');
+		if (!fileExists(componentPath)) {
+			violations.push(
+				`[${filePath}] Container GraphQL document must have a sibling .container.tsx component`,
+			);
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/frontend-architecture.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/frontend-architecture.ts
@@ -1,4 +1,3 @@
-import * as path from 'node:path';
 import {
 	fileExists,
 	getAllFiles,
@@ -6,9 +5,9 @@ import {
 	toPosixPath,
 } from '../utils/source-files.js';
 
-export async function checkShareThriftPageStoryCoverage(
+export function checkShareThriftPageStoryCoverage(
 	config: { uiSourcePath: string },
-): Promise<string[]> {
+): string[] {
 	const violations: string[] = [];
 	const sourceRoot = resolveSearchRoot(config.uiSourcePath);
 
@@ -34,9 +33,9 @@ export async function checkShareThriftPageStoryCoverage(
 	return violations;
 }
 
-export async function checkShareThriftContainerPlacement(
+export function checkShareThriftContainerPlacement(
 	config: { uiSourcePath: string },
-): Promise<string[]> {
+): string[] {
 	const violations: string[] = [];
 	const sourceRoot = resolveSearchRoot(config.uiSourcePath);
 
@@ -56,9 +55,9 @@ export async function checkShareThriftContainerPlacement(
 	return violations;
 }
 
-export async function checkShareThriftContainerGraphqlPairing(
+export function checkShareThriftContainerGraphqlPairing(
 	config: { uiSourcePath?: string } = {},
-): Promise<string[]> {
+): string[] {
 	const violations: string[] = [];
 	const sourceRoot = resolveSearchRoot(config.uiSourcePath ?? './src');
 

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/graphql-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/graphql-conventions.ts
@@ -1,0 +1,52 @@
+import * as path from 'node:path';
+import {
+	fileExists,
+	getFilesMatching,
+	readFile,
+} from '../utils/source-files.js';
+
+export async function checkShareThriftResolversHaveSchemaFiles(
+	config: { resolversGlob: string },
+): Promise<string[]> {
+	const violations: string[] = [];
+
+	for (const filePath of getFilesMatching(config.resolversGlob, '.resolvers.ts')) {
+		const schemaPath = filePath.replace(/\.resolvers\.ts$/, '.graphql');
+		if (!fileExists(schemaPath)) {
+			violations.push(
+				`[${filePath}] Resolver file must have a sibling .graphql schema file`,
+			);
+		}
+	}
+
+	return violations;
+}
+
+export async function checkShareThriftSchemaFilesHaveResolvers(
+	config: { graphqlGlob: string; excludeFiles?: string[] },
+): Promise<string[]> {
+	const violations: string[] = [];
+	const excludedFiles = new Set(config.excludeFiles ?? []);
+
+	for (const filePath of getFilesMatching(config.graphqlGlob, '.graphql')) {
+		if (excludedFiles.has(path.basename(filePath))) {
+			continue;
+		}
+
+		const content = readFile(filePath);
+		const exposesTopLevelOperations =
+			/(?:^|\n)\s*(?:extend\s+)?type\s+(?:Query|Mutation)\b/m.test(content);
+		if (!exposesTopLevelOperations) {
+			continue;
+		}
+
+		const resolverPath = filePath.replace(/\.graphql$/, '.resolvers.ts');
+		if (!fileExists(resolverPath)) {
+			violations.push(
+				`[${filePath}] GraphQL schema file must have a sibling .resolvers.ts file`,
+			);
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/persistence-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/persistence-conventions.ts
@@ -1,0 +1,68 @@
+import {
+	getFilesMatching,
+	getRelativeSegmentsAfter,
+	readFile,
+} from '../utils/source-files.js';
+
+export function checkShareThriftPersistenceFactoryExports(
+	config: {
+		persistenceDomainGlob: string;
+		persistenceReadonlyGlob: string;
+	},
+): Promise<string[]> {
+	const violations: string[] = [];
+
+	for (const filePath of getFilesMatching(config.persistenceDomainGlob, 'index.ts')) {
+		const segments = getRelativeSegmentsAfter(filePath, '/datasources/domain/');
+		if (segments.length !== 3) {
+			continue;
+		}
+
+		const content = readFile(filePath);
+		if (!content.includes('export const')) {
+			continue;
+		}
+		const unitOfWorkMatch = content.match(/get(\w+)UnitOfWork/);
+		if (!unitOfWorkMatch) {
+			continue;
+		}
+
+		const expectedFactoryName = `${unitOfWorkMatch[1]!}Persistence`;
+		const exportPattern = new RegExp(
+			`export\\s+const\\s+${expectedFactoryName}\\s*=\\s*\\(`,
+		);
+		if (!exportPattern.test(content)) {
+			violations.push(
+				`[${filePath}] Domain persistence index must export const ${expectedFactoryName}`,
+			);
+		}
+	}
+
+	for (const filePath of getFilesMatching(config.persistenceReadonlyGlob, 'index.ts')) {
+		const segments = getRelativeSegmentsAfter(filePath, '/datasources/readonly/');
+		if (segments.length !== 3) {
+			continue;
+		}
+
+		const content = readFile(filePath);
+		if (!content.includes('export const')) {
+			continue;
+		}
+		const readRepositoryMatch = content.match(/get(\w+)ReadRepository/);
+		if (!readRepositoryMatch) {
+			continue;
+		}
+
+		const expectedFactoryName = `${readRepositoryMatch[1]!}ReadRepositoryImpl`;
+		const exportPattern = new RegExp(
+			`export\\s+const\\s+${expectedFactoryName}\\s*=\\s*\\(`,
+		);
+		if (!exportPattern.test(content)) {
+			violations.push(
+				`[${filePath}] Readonly persistence index must export const ${expectedFactoryName}`,
+			);
+		}
+	}
+
+	return violations;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/checks/persistence-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/checks/persistence-conventions.ts
@@ -9,7 +9,7 @@ export function checkShareThriftPersistenceFactoryExports(
 		persistenceDomainGlob: string;
 		persistenceReadonlyGlob: string;
 	},
-): Promise<string[]> {
+): string[] {
 	const violations: string[] = [];
 
 	for (const filePath of getFilesMatching(config.persistenceDomainGlob, 'index.ts')) {

--- a/packages/sthrift-verification/arch-unit-tests/src/data-sources-mongoose-models.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/data-sources-mongoose-models.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkShareThriftModelExportNaming } from './checks/data-sources-mongoose-models-conventions.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift data-sources-mongoose-models checks', () => {
+	it('matches exported model names to the model file name', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(
+			workspace,
+			'models/listing/item-listing.model.ts',
+			[
+				'export const ItemListingModelFactory = () => ({});',
+				'export type ItemListingModelType = {};',
+				'export const ItemListingModelName = "ItemListing";',
+			].join('\n'),
+		);
+		writeFile(
+			workspace,
+			'models/user/personal-user.model.ts',
+			[
+				'export const UserModelFactory = () => ({});',
+				'export type UserModelType = {};',
+				'export const UserModelName = "User";',
+			].join('\n'),
+		);
+
+		const violations = await checkShareThriftModelExportNaming({
+			modelsGlob: `${workspace}/models/**`,
+		});
+
+		expect(violations).toHaveLength(3);
+		expect(violations[0]).toContain('PersonalUser');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/data-sources-mongoose-models.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/data-sources-mongoose-models.ts
@@ -1,0 +1,8 @@
+export {
+	checkShareThriftModelExportNaming,
+} from './checks/data-sources-mongoose-models-conventions.js';
+
+export {
+	describeDataSourcesMongooseModelsConventionTests,
+	type DataSourcesMongooseModelsConventionTestsConfig,
+} from './test-suites/data-sources-mongoose-models-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/domain.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/domain.test.ts
@@ -31,6 +31,11 @@ describe('ShareThrift domain checks', () => {
 		});
 
 		expect(violations).toHaveLength(2);
-		expect(violations[0]).toContain('user.domain-permissions.ts');
+		expect(violations).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('user.domain-permissions.ts'),
+				expect.stringContaining('user.visa.ts'),
+			]),
+		);
 	});
 });

--- a/packages/sthrift-verification/arch-unit-tests/src/domain.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/domain.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkShareThriftDomainContextAuthorizationFiles } from './checks/domain-conventions.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift domain checks', () => {
+	it('requires passport, domain-permissions, and visa files for each context', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(workspace, 'contexts/listing/index.ts');
+		writeFile(workspace, 'contexts/listing/listing.passport.ts');
+		writeFile(workspace, 'contexts/listing/listing.domain-permissions.ts');
+		writeFile(workspace, 'contexts/listing/listing.visa.ts');
+		writeFile(workspace, 'contexts/user/index.ts');
+		writeFile(workspace, 'contexts/user/user.passport.ts');
+
+		const violations = await checkShareThriftDomainContextAuthorizationFiles({
+			domainContextsGlob: `${workspace}/contexts/**`,
+		});
+
+		expect(violations).toHaveLength(2);
+		expect(violations[0]).toContain('user.domain-permissions.ts');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/domain.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/domain.ts
@@ -1,0 +1,8 @@
+export {
+	checkShareThriftDomainContextAuthorizationFiles,
+} from './checks/domain-conventions.js';
+
+export {
+	describeDomainConventionTests,
+	type DomainConventionTestsConfig,
+} from './test-suites/domain-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/fixtures/member-ordering/instance-mixed-ok.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/fixtures/member-ordering/instance-mixed-ok.ts
@@ -1,0 +1,17 @@
+export class InstanceMixedOk {
+  private readonly id = 'fixture';
+
+  constructor() {}
+
+  get label(): string {
+    return this.id;
+  }
+
+  set label(value: string) {
+    void value;
+  }
+
+  doThing(): string {
+    return this.id;
+  }
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/fixtures/member-ordering/static-instance-misordered.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/fixtures/member-ordering/static-instance-misordered.ts
@@ -1,0 +1,9 @@
+export class StaticInstanceMisordered {
+  doThing(): string {
+    return 'instance';
+  }
+
+  static fromFixture(): StaticInstanceMisordered {
+    return new StaticInstanceMisordered();
+  }
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/frontend.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/frontend.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	checkShareThriftContainerPlacement,
+	checkShareThriftContainerGraphqlPairing,
+	checkShareThriftPageStoryCoverage,
+} from './checks/frontend-architecture.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift frontend checks', () => {
+	it('requires page story files, container placement, and container component pairs', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(workspace, 'src/components/pages/home/pages/home-page.tsx', 'export const HomePage = () => null;\n');
+		writeFile(workspace, 'src/components/pages/home/pages/home-page.stories.tsx', 'export default {};\n');
+		writeFile(
+			workspace,
+			'src/components/pages/account/profile/pages/profile-page.tsx',
+			'export const ProfilePage = () => null;\n',
+		);
+		writeFile(workspace, 'src/components/pages/home/components/home.container.graphql', 'query Home { home }\n');
+		writeFile(workspace, 'src/components/pages/home/components/home.container.tsx', 'export const HomeContainer = () => null;\n');
+		writeFile(workspace, 'src/components/pages/account/components/profile.container.graphql', 'query Profile { profile }\n');
+		writeFile(workspace, 'src/pages/rogue.container.tsx', 'export const RogueContainer = () => null;\n');
+
+		const pageViolations = await checkShareThriftPageStoryCoverage({
+			uiSourcePath: `${workspace}/src`,
+		});
+		const placementViolations = await checkShareThriftContainerPlacement({
+			uiSourcePath: `${workspace}/src`,
+		});
+		const containerViolations = await checkShareThriftContainerGraphqlPairing({
+			uiSourcePath: `${workspace}/src`,
+		});
+
+		expect(pageViolations).toHaveLength(1);
+		expect(pageViolations[0]).toContain('profile-page.tsx');
+		expect(placementViolations).toHaveLength(1);
+		expect(placementViolations[0]).toContain('rogue.container.tsx');
+		expect(containerViolations).toHaveLength(1);
+		expect(containerViolations[0]).toContain('profile.container.graphql');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/frontend.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/frontend.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe('ShareThrift frontend checks', () => {
-	it('requires page story files, container placement, and container component pairs', async () => {
+	it('requires page story files', async () => {
 		const workspace = createTempWorkspace();
 		workspaces.push(workspace);
 
@@ -30,26 +30,43 @@ describe('ShareThrift frontend checks', () => {
 			'src/components/pages/account/profile/pages/profile-page.tsx',
 			'export const ProfilePage = () => null;\n',
 		);
+
+		const violations = await checkShareThriftPageStoryCoverage({
+			uiSourcePath: `${workspace}/src`,
+		});
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toContain('profile-page.tsx');
+	});
+
+	it('requires containers inside page component directories', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(workspace, 'src/components/pages/home/components/home.container.tsx', 'export const HomeContainer = () => null;\n');
+		writeFile(workspace, 'src/pages/rogue.container.tsx', 'export const RogueContainer = () => null;\n');
+
+		const violations = await checkShareThriftContainerPlacement({
+			uiSourcePath: `${workspace}/src`,
+		});
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toContain('rogue.container.tsx');
+	});
+
+	it('requires container components to have matching graphql files', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
 		writeFile(workspace, 'src/components/pages/home/components/home.container.graphql', 'query Home { home }\n');
 		writeFile(workspace, 'src/components/pages/home/components/home.container.tsx', 'export const HomeContainer = () => null;\n');
 		writeFile(workspace, 'src/components/pages/account/components/profile.container.graphql', 'query Profile { profile }\n');
-		writeFile(workspace, 'src/pages/rogue.container.tsx', 'export const RogueContainer = () => null;\n');
 
-		const pageViolations = await checkShareThriftPageStoryCoverage({
-			uiSourcePath: `${workspace}/src`,
-		});
-		const placementViolations = await checkShareThriftContainerPlacement({
-			uiSourcePath: `${workspace}/src`,
-		});
-		const containerViolations = await checkShareThriftContainerGraphqlPairing({
+		const violations = await checkShareThriftContainerGraphqlPairing({
 			uiSourcePath: `${workspace}/src`,
 		});
 
-		expect(pageViolations).toHaveLength(1);
-		expect(pageViolations[0]).toContain('profile-page.tsx');
-		expect(placementViolations).toHaveLength(1);
-		expect(placementViolations[0]).toContain('rogue.container.tsx');
-		expect(containerViolations).toHaveLength(1);
-		expect(containerViolations[0]).toContain('profile.container.graphql');
+		expect(violations).toHaveLength(1);
+		expect(violations[0]).toContain('profile.container.graphql');
 	});
 });

--- a/packages/sthrift-verification/arch-unit-tests/src/frontend.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/frontend.ts
@@ -1,0 +1,15 @@
+export {
+	checkShareThriftPageStoryCoverage,
+	checkShareThriftContainerPlacement,
+	checkShareThriftContainerGraphqlPairing,
+} from './checks/frontend-architecture.js';
+
+export {
+	describeFrontendArchitectureTests,
+	type FrontendArchitectureTestsConfig,
+} from './test-suites/frontend-architecture.js';
+
+export {
+	describeNamingConventionTests,
+	type NamingConventionsConfig,
+} from './test-suites/naming-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/graphql.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/graphql.test.ts
@@ -18,6 +18,26 @@ afterEach(() => {
 });
 
 describe('ShareThrift graphql checks', () => {
+	it('returns no violations for a fully compliant workspace', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(workspace, 'schema/types/user.resolvers.ts', 'export default {};\n');
+		writeFile(workspace, 'schema/types/user.graphql', 'type User { id: ID! }\n');
+		writeFile(workspace, 'schema/types/listing.resolvers.ts', 'export default {};\n');
+		writeFile(workspace, 'schema/types/listing.graphql', 'type Listing { id: ID! }\n');
+
+		const resolverViolations = await checkShareThriftResolversHaveSchemaFiles({
+			resolversGlob: `${workspace}/schema/types/**`,
+		});
+		const schemaViolations = await checkShareThriftSchemaFilesHaveResolvers({
+			graphqlGlob: `${workspace}/schema/types/**/*.graphql`,
+		});
+
+		expect(resolverViolations).toEqual([]);
+		expect(schemaViolations).toEqual([]);
+	});
+
 	it('pairs resolver files with schema files in both directions', async () => {
 		const workspace = createTempWorkspace();
 		workspaces.push(workspace);

--- a/packages/sthrift-verification/arch-unit-tests/src/graphql.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/graphql.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	checkShareThriftResolversHaveSchemaFiles,
+	checkShareThriftSchemaFilesHaveResolvers,
+} from './checks/graphql-conventions.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift graphql checks', () => {
+	it('pairs resolver files with schema files in both directions', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(workspace, 'schema/types/user.resolvers.ts', 'export default {};\n');
+		writeFile(workspace, 'schema/types/user.graphql', 'type User { id: ID! }\n');
+		writeFile(workspace, 'schema/types/listing.resolvers.ts', 'export default {};\n');
+		writeFile(
+			workspace,
+			'schema/types/account.graphql',
+			'extend type Query { account: Account }\n\ntype Account { id: ID! }\n',
+		);
+
+		const resolverViolations = await checkShareThriftResolversHaveSchemaFiles({
+			resolversGlob: `${workspace}/schema/types/**`,
+		});
+		const schemaViolations = await checkShareThriftSchemaFilesHaveResolvers({
+			graphqlGlob: `${workspace}/schema/types/**/*.graphql`,
+		});
+
+		expect(resolverViolations).toHaveLength(1);
+		expect(resolverViolations[0]).toContain('listing.resolvers.ts');
+		expect(schemaViolations).toHaveLength(1);
+		expect(schemaViolations[0]).toContain('account.graphql');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/graphql.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/graphql.ts
@@ -1,0 +1,15 @@
+export {
+	checkShareThriftResolversHaveSchemaFiles,
+	checkShareThriftSchemaFilesHaveResolvers,
+} from './checks/graphql-conventions.js';
+
+export {
+	describeGraphqlResolverConventionsTests,
+	type GraphqlResolverConventionsTestsConfig,
+	type GraphqlFlatStructureTestsConfig,
+} from './test-suites/graphql-resolver-conventions.js';
+
+export {
+	describeGraphqlSchemaConventionsTests,
+	type GraphqlSchemaConventionsTestsConfig,
+} from './test-suites/graphql-schema-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/index.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/index.ts
@@ -1,0 +1,6 @@
+export * from './application-services.js';
+export * from './data-sources-mongoose-models.js';
+export * from './domain.js';
+export * from './frontend.js';
+export * from './graphql.js';
+export * from './persistence.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/member-ordering.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/member-ordering.test.ts
@@ -1,9 +1,85 @@
-import { describeMemberOrderingTests, type MemberOrderingTestsConfig } from '@cellix/arch-unit-tests/general';
+import path from 'node:path';
+import { checkMemberOrdering } from '@cellix/arch-unit-tests/general';
+import { describe, expect, it } from 'vitest';
+import { getAllFiles } from './utils/source-files.js';
 
-const config: MemberOrderingTestsConfig = {
-  domainSourcePath: '../domain/src',
-  persistenceSourcePath: '../persistence/src',
-  graphqlSourcePath: '../graphql/src/schema/types',
-};
+function getTypeScriptFiles(
+  sourcePath: string,
+  predicate: (filePath: string) => boolean = () => true,
+): string[] {
+  return getAllFiles(path.resolve(process.cwd(), sourcePath)).filter((filePath) => {
+    if (!filePath.endsWith('.ts')) {
+      return false;
+    }
 
-describeMemberOrderingTests(config);
+    if (filePath.endsWith('.test.ts')) {
+      return false;
+    }
+
+    return predicate(filePath);
+  });
+}
+
+describe('Member Ordering Conventions', () => {
+  it('domain classes should follow member ordering convention', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: getTypeScriptFiles('../../sthrift/domain/src/domain'),
+    });
+
+    expect(violations).toStrictEqual([]);
+  }, 30000);
+
+  it('aggregate root classes should follow member ordering convention', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: getTypeScriptFiles(
+        '../../sthrift/domain/src/domain',
+        (filePath) => filePath.endsWith('.aggregate.ts'),
+      ),
+    });
+
+    expect(violations).toStrictEqual([]);
+  }, 30000);
+
+  it('entity classes should follow member ordering convention', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: getTypeScriptFiles(
+        '../../sthrift/domain/src/domain',
+        (filePath) => filePath.endsWith('.entity.ts'),
+      ),
+    });
+
+    expect(violations).toStrictEqual([]);
+  }, 30000);
+
+  it('persistence classes should follow member ordering convention', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: getTypeScriptFiles('../../sthrift/persistence/src'),
+    });
+
+    expect(violations).toStrictEqual([]);
+  }, 30000);
+
+  it('resolver classes should follow member ordering convention', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: getTypeScriptFiles('../../sthrift/graphql/src/schema/types'),
+    });
+
+    expect(violations).toStrictEqual([]);
+  }, 30000);
+
+  it('allows mixing instance methods and accessors within the same instance-member group', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: ['./src/fixtures/member-ordering/instance-mixed-ok.ts'],
+    });
+
+    expect(violations).toStrictEqual([]);
+  });
+
+  it('still enforces grouping of static vs instance members', async () => {
+    const violations = await checkMemberOrdering({
+      sourceGlobs: ['./src/fixtures/member-ordering/static-instance-misordered.ts'],
+    });
+
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/persistence.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/persistence.test.ts
@@ -56,7 +56,11 @@ describe('ShareThrift persistence checks', () => {
 		});
 
 		expect(violations).toHaveLength(2);
-		expect(violations[0]).toContain('PersonalUserPersistence');
-		expect(violations[1]).toContain('PersonalUserReadRepositoryImpl');
+		expect(violations).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('PersonalUserPersistence'),
+				expect.stringContaining('PersonalUserReadRepositoryImpl'),
+			]),
+		);
 	});
 });

--- a/packages/sthrift-verification/arch-unit-tests/src/persistence.test.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/persistence.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkShareThriftPersistenceFactoryExports } from './checks/persistence-conventions.js';
+import {
+	createTempWorkspace,
+	removeTempWorkspace,
+	writeFile,
+} from './test-helpers.js';
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		removeTempWorkspace(workspace);
+	}
+});
+
+describe('ShareThrift persistence checks', () => {
+	it('requires expected factory exports in domain and readonly entity indexes', async () => {
+		const workspace = createTempWorkspace();
+		workspaces.push(workspace);
+
+		writeFile(
+			workspace,
+			'datasources/domain/listing/item/index.ts',
+			'export const ItemListingPersistence = () => ({ ItemListingUnitOfWork: {} });\n',
+		);
+		writeFile(
+			workspace,
+			'datasources/domain/user/personal-user/index.ts',
+			[
+				'import { getPersonalUserUnitOfWork } from "./personal-user.uow.ts";',
+				'export const WrongPersistence = () => ({',
+				'\tPersonalUserUnitOfWork: getPersonalUserUnitOfWork(),',
+				'});',
+			].join('\n'),
+		);
+		writeFile(
+			workspace,
+			'datasources/readonly/listing/item/index.ts',
+			'export const ItemListingReadRepositoryImpl = () => ({ ItemListingReadRepo: {} });\n',
+		);
+		writeFile(
+			workspace,
+			'datasources/readonly/user/personal-user/index.ts',
+			[
+				'import { getPersonalUserReadRepository } from "./personal-user.read-repository.ts";',
+				'export const WrongReadRepository = () => ({',
+				'\tPersonalUserReadRepo: getPersonalUserReadRepository(),',
+				'});',
+			].join('\n'),
+		);
+
+		const violations = await checkShareThriftPersistenceFactoryExports({
+			persistenceDomainGlob: `${workspace}/datasources/domain/**`,
+			persistenceReadonlyGlob: `${workspace}/datasources/readonly/**`,
+		});
+
+		expect(violations).toHaveLength(2);
+		expect(violations[0]).toContain('PersonalUserPersistence');
+		expect(violations[1]).toContain('PersonalUserReadRepositoryImpl');
+	});
+});

--- a/packages/sthrift-verification/arch-unit-tests/src/persistence.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/persistence.ts
@@ -1,0 +1,8 @@
+export {
+	checkShareThriftPersistenceFactoryExports,
+} from './checks/persistence-conventions.js';
+
+export {
+	describePersistenceConventionTests,
+	type PersistenceConventionTestsConfig,
+} from './test-suites/persistence-conventions.js';

--- a/packages/sthrift-verification/arch-unit-tests/src/test-helpers.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-helpers.ts
@@ -1,0 +1,22 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export function createTempWorkspace(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'sthrift-arch-tests-'));
+}
+
+export function removeTempWorkspace(workspacePath: string): void {
+	fs.rmSync(workspacePath, { recursive: true, force: true });
+}
+
+export function writeFile(
+	workspacePath: string,
+	relativePath: string,
+	content = '',
+): string {
+	const filePath = path.join(workspacePath, relativePath);
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content);
+	return filePath;
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/application-services-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/application-services-conventions.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftApplicationServicesFactoryExports } from '../checks/application-services-conventions.js';
+
+export interface ApplicationServicesConventionTestsConfig
+{
+	applicationServicesGlob: string;
+	applicationServicesAllGlob: string;
+}
+
+export function describeApplicationServicesConventionTests(
+	config: ApplicationServicesConventionTestsConfig,
+): void {
+	describe('ShareThrift Application Services Conventions', () => {
+		it('entity indexes must export a factory named after the entity folder', async () => {
+			const violations = await checkShareThriftApplicationServicesFactoryExports({
+				applicationServicesGlob: config.applicationServicesGlob,
+			});
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/data-sources-mongoose-models-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/data-sources-mongoose-models-conventions.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftModelExportNaming } from '../checks/data-sources-mongoose-models-conventions.js';
+
+export interface DataSourcesMongooseModelsConventionTestsConfig
+{
+	modelsGlob: string;
+	allGlob: string;
+}
+
+export function describeDataSourcesMongooseModelsConventionTests(
+	config: DataSourcesMongooseModelsConventionTestsConfig,
+): void {
+	describe('ShareThrift Data Sources Mongoose Models Conventions', () => {
+		it('model export names must match the model file name', async () => {
+			const violations = await checkShareThriftModelExportNaming({
+				modelsGlob: config.modelsGlob,
+			});
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/domain-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/domain-conventions.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftDomainContextAuthorizationFiles } from '../checks/domain-conventions.js';
+
+export interface DomainConventionTestsConfig {
+	domainContextsGlob: string;
+}
+
+export function describeDomainConventionTests(
+	config: DomainConventionTestsConfig,
+): void {
+	describe('ShareThrift Domain Conventions', () => {
+		it('contexts must define passport, domain-permissions, and visa files', async () => {
+			const violations =
+				await checkShareThriftDomainContextAuthorizationFiles(config);
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/frontend-architecture.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/frontend-architecture.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftContainerPlacement } from '../checks/frontend-architecture.js';
+
+export interface FrontendArchitectureTestsConfig
+{
+	uiSourcePath: string;
+	testName?: string;
+}
+
+export function describeFrontendArchitectureTests(
+	config: FrontendArchitectureTestsConfig,
+): void {
+	describe(`ShareThrift Frontend Architecture - ${config.testName || 'UI'}`, () => {
+		it('container components must live inside components directories', async () => {
+			const violations = await checkShareThriftContainerPlacement({
+				uiSourcePath: config.uiSourcePath,
+			});
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/graphql-resolver-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/graphql-resolver-conventions.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftResolversHaveSchemaFiles } from '../checks/graphql-conventions.js';
+
+export interface GraphqlResolverConventionsTestsConfig {
+	resolversGlob: string;
+	entityFilesPattern: string;
+	repositoryFilesPattern: string;
+	uowFilesPattern: string;
+	infrastructureServicesPattern?: string;
+	persistenceFolder?: string;
+}
+
+export interface GraphqlFlatStructureTestsConfig {
+	typesDirectoryPath: string;
+	allowedSubdirectories?: string[];
+}
+
+export function describeGraphqlResolverConventionsTests(
+	config: GraphqlResolverConventionsTestsConfig,
+	_flatStructureConfig?: GraphqlFlatStructureTestsConfig,
+): void {
+	describe('ShareThrift GraphQL Resolver Conventions', () => {
+		it('resolver files must have sibling schema files', async () => {
+			const violations = await checkShareThriftResolversHaveSchemaFiles({
+				resolversGlob: config.resolversGlob,
+			});
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/graphql-schema-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/graphql-schema-conventions.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftSchemaFilesHaveResolvers } from '../checks/graphql-conventions.js';
+
+export interface GraphqlSchemaConventionsTestsConfig {
+	graphqlGlob: string;
+	excludeFiles?: string[];
+}
+
+export function describeGraphqlSchemaConventionsTests(
+	config: GraphqlSchemaConventionsTestsConfig,
+): void {
+	describe('ShareThrift GraphQL Schema Conventions', () => {
+		it('schema files must have sibling resolver files unless explicitly excluded', async () => {
+			const violations = await checkShareThriftSchemaFilesHaveResolvers(config);
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/naming-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/naming-conventions.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftContainerGraphqlPairing } from '../checks/frontend-architecture.js';
+
+export interface NamingConventionsConfig {
+	uiSourcePath?: string;
+}
+
+export function describeNamingConventionTests(
+	config?: NamingConventionsConfig,
+): void {
+	describe('ShareThrift Naming Conventions', () => {
+		it('container graphql files must have sibling container components', async () => {
+			const violations = await checkShareThriftContainerGraphqlPairing(config);
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/test-suites/persistence-conventions.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/test-suites/persistence-conventions.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { checkShareThriftPersistenceFactoryExports } from '../checks/persistence-conventions.js';
+
+export interface PersistenceConventionTestsConfig
+{
+	persistenceDomainGlob: string;
+	persistenceReadonlyGlob: string;
+	persistenceAllGlob: string;
+}
+
+export function describePersistenceConventionTests(
+	config: PersistenceConventionTestsConfig,
+): void {
+	describe('ShareThrift Persistence Conventions', () => {
+		it('entity indexes must export the expected persistence factories', async () => {
+			const violations = await checkShareThriftPersistenceFactoryExports({
+				persistenceDomainGlob: config.persistenceDomainGlob,
+				persistenceReadonlyGlob: config.persistenceReadonlyGlob,
+			});
+			expect(violations).toStrictEqual([]);
+		}, 30000);
+	});
+}

--- a/packages/sthrift-verification/arch-unit-tests/src/utils/source-files.ts
+++ b/packages/sthrift-verification/arch-unit-tests/src/utils/source-files.ts
@@ -1,0 +1,88 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export function toPosixPath(value: string): string {
+	return value.split(path.sep).join('/');
+}
+
+export function resolveSearchRoot(pattern: string): string {
+	const [root] = pattern.split('*');
+	return path.resolve(process.cwd(), root || '.');
+}
+
+export function fileExists(filePath: string): boolean {
+	return fs.existsSync(filePath);
+}
+
+export function readFile(filePath: string): string {
+	return fs.readFileSync(filePath, 'utf8');
+}
+
+export function getAllFiles(rootPath: string): string[] {
+	if (!fileExists(rootPath)) {
+		return [];
+	}
+
+	const files: string[] = [];
+	const queue = [rootPath];
+
+	while (queue.length > 0) {
+		const currentPath = queue.pop()!;
+		const stats = fs.statSync(currentPath);
+		if (stats.isDirectory()) {
+			for (const entry of fs.readdirSync(currentPath)) {
+				queue.push(path.join(currentPath, entry));
+			}
+			continue;
+		}
+		files.push(currentPath);
+	}
+
+	return files.sort((left, right) => left.localeCompare(right));
+}
+
+export function getFilesMatching(pattern: string, suffix: string): string[] {
+	return getAllFiles(resolveSearchRoot(pattern)).filter((filePath) =>
+		filePath.endsWith(suffix),
+	);
+}
+
+export function getRelativeSegmentsAfter(
+	filePath: string,
+	anchor: string,
+): string[] {
+	const normalizedPath = toPosixPath(filePath);
+	const anchorIndex = normalizedPath.lastIndexOf(anchor);
+	if (anchorIndex === -1) {
+		return [];
+	}
+
+	return normalizedPath
+		.slice(anchorIndex + anchor.length)
+		.split('/')
+		.filter(Boolean);
+}
+
+export function getImmediateDirectories(rootPath: string): string[] {
+	if (!fileExists(rootPath)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(rootPath, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => path.join(rootPath, entry.name))
+		.sort((left, right) => left.localeCompare(right));
+}
+
+export function toPascalCase(value: string): string {
+	return value
+		.split(/[^a-zA-Z0-9]+/)
+		.filter(Boolean)
+		.map((segment) => segment[0]!.toUpperCase() + segment.slice(1))
+		.join('');
+}
+
+export function getSiblingPath(filePath: string, suffix: string): string {
+	return path.join(path.dirname(filePath), suffix);
+}

--- a/packages/sthrift-verification/arch-unit-tests/tsconfig.json
+++ b/packages/sthrift-verification/arch-unit-tests/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "@cellix/typescript-config/node.json",
   "include": [
-    "src/**/*",
-    "../../cellix/**/*.ts",
-    "../**/*.ts",
-    "../../apps/**/*.ts"
+    "src/**/*"
   ],
   "exclude": [
     "node_modules",

--- a/packages/sthrift/application-services/package.json
+++ b/packages/sthrift/application-services/package.json
@@ -33,6 +33,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"
 	},

--- a/packages/sthrift/application-services/src/arch-unit-tests/application-services-conventions.test.ts
+++ b/packages/sthrift/application-services/src/arch-unit-tests/application-services-conventions.test.ts
@@ -3,9 +3,20 @@ import {
 	type ApplicationServicesConventionTestsConfig,
 } from '@cellix/arch-unit-tests/application-services';
 
-const config: ApplicationServicesConventionTestsConfig = {
+import {
+	describeApplicationServicesConventionTests as describeShareThriftApplicationServicesConventionTests,
+	type ApplicationServicesConventionTestsConfig as ShareThriftApplicationServicesConventionTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/application-services';
+
+const cellixConfig: ApplicationServicesConventionTestsConfig = {
 	applicationServicesGlob: '../application-services/src/contexts/**',
 	applicationServicesAllGlob: '../application-services/src/**',
 };
 
-describeApplicationServicesConventionTests(config);
+const shareThriftConfig: ShareThriftApplicationServicesConventionTestsConfig = {
+	applicationServicesGlob: '../application-services/src/contexts/**',
+	applicationServicesAllGlob: '../application-services/src/**',
+};
+
+describeApplicationServicesConventionTests(cellixConfig);
+describeShareThriftApplicationServicesConventionTests(shareThriftConfig);

--- a/packages/sthrift/data-sources-mongoose-models/package.json
+++ b/packages/sthrift/data-sources-mongoose-models/package.json
@@ -28,6 +28,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"typescript": "^5.8.3",
 		"rimraf": "^6.0.1",
 		"vitest": "catalog:"

--- a/packages/sthrift/data-sources-mongoose-models/src/arch-unit-tests/data-sources-mongoose-models-conventions.test.ts
+++ b/packages/sthrift/data-sources-mongoose-models/src/arch-unit-tests/data-sources-mongoose-models-conventions.test.ts
@@ -2,10 +2,20 @@ import {
 	describeDataSourcesMongooseModelsConventionTests,
 	type DataSourcesMongooseModelsConventionTestsConfig,
 } from '@cellix/arch-unit-tests/data-sources-mongoose-models';
+import {
+	describeDataSourcesMongooseModelsConventionTests as describeShareThriftDataSourcesMongooseModelsConventionTests,
+	type DataSourcesMongooseModelsConventionTestsConfig as ShareThriftDataSourcesMongooseModelsConventionTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/data-sources-mongoose-models';
 
-const config: DataSourcesMongooseModelsConventionTestsConfig = {
+const cellixConfig: DataSourcesMongooseModelsConventionTestsConfig = {
 	modelsGlob: '../data-sources-mongoose-models/src/models/**',
 	allGlob: '../data-sources-mongoose-models/src/**',
 };
 
-describeDataSourcesMongooseModelsConventionTests(config);
+const shareThriftConfig: ShareThriftDataSourcesMongooseModelsConventionTestsConfig = {
+	modelsGlob: '../data-sources-mongoose-models/src/models/**',
+	allGlob: '../data-sources-mongoose-models/src/**',
+};
+
+describeDataSourcesMongooseModelsConventionTests(cellixConfig);
+describeShareThriftDataSourcesMongooseModelsConventionTests(shareThriftConfig);

--- a/packages/sthrift/domain/package.json
+++ b/packages/sthrift/domain/package.json
@@ -37,6 +37,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"@cucumber/cucumber": "^12.2.0",
 		"@cucumber/node": "^0.4.0",
 		"@cucumber/pretty-formatter": "^1.0.1",

--- a/packages/sthrift/domain/src/arch-unit-tests/domain-conventions.test.ts
+++ b/packages/sthrift/domain/src/arch-unit-tests/domain-conventions.test.ts
@@ -3,8 +3,18 @@ import {
 	type DomainConventionTestsConfig,
 } from '@cellix/arch-unit-tests/domain';
 
-const config: DomainConventionTestsConfig = {
+import {
+	describeDomainConventionTests as describeShareThriftDomainConventionTests,
+	type DomainConventionTestsConfig as ShareThriftDomainConventionTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/domain';
+
+const cellixConfig: DomainConventionTestsConfig = {
 	domainContextsGlob: '../domain/src/domain/contexts/**',
 };
 
-describeDomainConventionTests(config);
+const shareThriftConfig: ShareThriftDomainConventionTestsConfig = {
+	domainContextsGlob: '../domain/src/domain/contexts/**',
+};
+
+describeDomainConventionTests(cellixConfig);
+describeShareThriftDomainConventionTests(shareThriftConfig);

--- a/packages/sthrift/graphql/package.json
+++ b/packages/sthrift/graphql/package.json
@@ -47,6 +47,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"@types/graphql-depth-limit": "^1.1.6",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"

--- a/packages/sthrift/graphql/src/arch-unit-tests/graphql-resolver-conventions.test.ts
+++ b/packages/sthrift/graphql/src/arch-unit-tests/graphql-resolver-conventions.test.ts
@@ -4,7 +4,13 @@ import {
 	type GraphqlFlatStructureTestsConfig,
 } from '@cellix/arch-unit-tests/graphql';
 
-const resolverConfig: GraphqlResolverConventionsTestsConfig = {
+import {
+	describeGraphqlResolverConventionsTests as describeShareThriftGraphqlResolverConventionsTests,
+	type GraphqlResolverConventionsTestsConfig as ShareThriftGraphqlResolverConventionsTestsConfig,
+	type GraphqlFlatStructureTestsConfig as ShareThriftGraphqlFlatStructureTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/graphql';
+
+const cellixResolverConfig: GraphqlResolverConventionsTestsConfig = {
 	resolversGlob: '../graphql/src/schema/types/**',
 	entityFilesPattern: '../domain/src/domain/contexts/**/*.entity.ts',
 	repositoryFilesPattern: '../domain/src/domain/contexts/**/*.repository.ts',
@@ -13,9 +19,27 @@ const resolverConfig: GraphqlResolverConventionsTestsConfig = {
 	persistenceFolder: '../persistence/**',
 };
 
-const flatStructureConfig: GraphqlFlatStructureTestsConfig = {
+const shareThriftResolverConfig: ShareThriftGraphqlResolverConventionsTestsConfig = {
+	resolversGlob: '../graphql/src/schema/types/**',
+	entityFilesPattern: '../domain/src/domain/contexts/**/*.entity.ts',
+	repositoryFilesPattern: '../domain/src/domain/contexts/**/*.repository.ts',
+	uowFilesPattern: '../domain/src/domain/contexts/**/*.uow.ts',
+	infrastructureServicesPattern: '../../cellix/service-*/**',
+	persistenceFolder: '../persistence/**',
+};
+
+const cellixFlatStructureConfig: GraphqlFlatStructureTestsConfig = {
 	typesDirectoryPath: '../graphql/src/schema/types',
 	allowedSubdirectories: ['features'],
 };
 
-describeGraphqlResolverConventionsTests(resolverConfig, flatStructureConfig);
+const shareThriftFlatStructureConfig: ShareThriftGraphqlFlatStructureTestsConfig = {
+	typesDirectoryPath: '../graphql/src/schema/types',
+	allowedSubdirectories: ['features'],
+};
+
+describeGraphqlResolverConventionsTests(cellixResolverConfig, cellixFlatStructureConfig);
+describeShareThriftGraphqlResolverConventionsTests(
+	shareThriftResolverConfig,
+	shareThriftFlatStructureConfig,
+);

--- a/packages/sthrift/graphql/src/arch-unit-tests/graphql-schema-conventions.test.ts
+++ b/packages/sthrift/graphql/src/arch-unit-tests/graphql-schema-conventions.test.ts
@@ -3,9 +3,20 @@ import {
 	type GraphqlSchemaConventionsTestsConfig,
 } from '@cellix/arch-unit-tests/graphql';
 
-const schemaConfig: GraphqlSchemaConventionsTestsConfig = {
+import {
+	describeGraphqlSchemaConventionsTests as describeShareThriftGraphqlSchemaConventionsTests,
+	type GraphqlSchemaConventionsTestsConfig as ShareThriftGraphqlSchemaConventionsTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/graphql';
+
+const cellixSchemaConfig: GraphqlSchemaConventionsTestsConfig = {
 	graphqlGlob: '../graphql/src/schema/types/**/*.graphql',
 	excludeFiles: ['shared-types.graphql', 'listing.graphql', 'appeal-request.graphql'],
 };
 
-describeGraphqlSchemaConventionsTests(schemaConfig);
+const shareThriftSchemaConfig: ShareThriftGraphqlSchemaConventionsTestsConfig = {
+	graphqlGlob: '../graphql/src/schema/types/**/*.graphql',
+	excludeFiles: ['shared-types.graphql', 'listing.graphql', 'appeal-request.graphql'],
+};
+
+describeGraphqlSchemaConventionsTests(cellixSchemaConfig);
+describeShareThriftGraphqlSchemaConventionsTests(shareThriftSchemaConfig);

--- a/packages/sthrift/persistence/package.json
+++ b/packages/sthrift/persistence/package.json
@@ -40,6 +40,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"
 	},

--- a/packages/sthrift/persistence/src/arch-unit-tests/persistence-conventions.test.ts
+++ b/packages/sthrift/persistence/src/arch-unit-tests/persistence-conventions.test.ts
@@ -3,10 +3,22 @@ import {
 	type PersistenceConventionTestsConfig,
 } from '@cellix/arch-unit-tests/persistence';
 
-const config: PersistenceConventionTestsConfig = {
+import {
+	describePersistenceConventionTests as describeShareThriftPersistenceConventionTests,
+	type PersistenceConventionTestsConfig as ShareThriftPersistenceConventionTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/persistence';
+
+const cellixConfig: PersistenceConventionTestsConfig = {
 	persistenceDomainGlob: '../persistence/src/datasources/domain/**',
 	persistenceReadonlyGlob: '../persistence/src/datasources/readonly/**',
 	persistenceAllGlob: '../persistence/src/**',
 };
 
-describePersistenceConventionTests(config);
+const shareThriftConfig: ShareThriftPersistenceConventionTestsConfig = {
+	persistenceDomainGlob: '../persistence/src/datasources/domain/**',
+	persistenceReadonlyGlob: '../persistence/src/datasources/readonly/**',
+	persistenceAllGlob: '../persistence/src/**',
+};
+
+describePersistenceConventionTests(cellixConfig);
+describeShareThriftPersistenceConventionTests(shareThriftConfig);

--- a/packages/sthrift/ui-admin-route-root/package.json
+++ b/packages/sthrift/ui-admin-route-root/package.json
@@ -28,6 +28,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"@storybook/react": "^10.1.11",
 		"@types/react": "^19.1.9",
 		"@types/react-dom": "^19.1.7",

--- a/packages/sthrift/ui-admin-route-root/src/arch-unit-tests/frontend-architecture.test.ts
+++ b/packages/sthrift/ui-admin-route-root/src/arch-unit-tests/frontend-architecture.test.ts
@@ -2,10 +2,20 @@ import {
 	describeFrontendArchitectureTests,
 	type FrontendArchitectureTestsConfig,
 } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeFrontendArchitectureTests as describeShareThriftFrontendArchitectureTests,
+	type FrontendArchitectureTestsConfig as ShareThriftFrontendArchitectureTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
-const config: FrontendArchitectureTestsConfig = {
+const cellixConfig: FrontendArchitectureTestsConfig = {
 	uiSourcePath: './src',
 	testName: 'UI Admin Route Root',
 };
 
-describeFrontendArchitectureTests(config);
+const shareThriftConfig: ShareThriftFrontendArchitectureTestsConfig = {
+	uiSourcePath: './src',
+	testName: 'UI Admin Route Root',
+};
+
+describeFrontendArchitectureTests(cellixConfig);
+describeShareThriftFrontendArchitectureTests(shareThriftConfig);

--- a/packages/sthrift/ui-admin-route-root/src/arch-unit-tests/naming-conventions.test.ts
+++ b/packages/sthrift/ui-admin-route-root/src/arch-unit-tests/naming-conventions.test.ts
@@ -1,3 +1,7 @@
 import { describeNamingConventionTests } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeNamingConventionTests as describeShareThriftNamingConventionTests,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
 describeNamingConventionTests();
+describeShareThriftNamingConventionTests();

--- a/packages/sthrift/ui-sharethrift-route-root/package.json
+++ b/packages/sthrift/ui-sharethrift-route-root/package.json
@@ -31,6 +31,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"@storybook/react": "^10.1.11",
 		"@types/react": "^19.1.9",
 		"@types/react-dom": "^19.1.7",

--- a/packages/sthrift/ui-sharethrift-route-root/src/arch-unit-tests/frontend-architecture.test.ts
+++ b/packages/sthrift/ui-sharethrift-route-root/src/arch-unit-tests/frontend-architecture.test.ts
@@ -2,10 +2,20 @@ import {
 	describeFrontendArchitectureTests,
 	type FrontendArchitectureTestsConfig,
 } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeFrontendArchitectureTests as describeShareThriftFrontendArchitectureTests,
+	type FrontendArchitectureTestsConfig as ShareThriftFrontendArchitectureTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
-const config: FrontendArchitectureTestsConfig = {
+const cellixConfig: FrontendArchitectureTestsConfig = {
 	uiSourcePath: './src',
 	testName: 'UI ShareThrift Route Root',
 };
 
-describeFrontendArchitectureTests(config);
+const shareThriftConfig: ShareThriftFrontendArchitectureTestsConfig = {
+	uiSourcePath: './src',
+	testName: 'UI ShareThrift Route Root',
+};
+
+describeFrontendArchitectureTests(cellixConfig);
+describeShareThriftFrontendArchitectureTests(shareThriftConfig);

--- a/packages/sthrift/ui-sharethrift-route-root/src/arch-unit-tests/naming-conventions.test.ts
+++ b/packages/sthrift/ui-sharethrift-route-root/src/arch-unit-tests/naming-conventions.test.ts
@@ -1,3 +1,7 @@
 import { describeNamingConventionTests } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeNamingConventionTests as describeShareThriftNamingConventionTests,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
 describeNamingConventionTests();
+describeShareThriftNamingConventionTests();

--- a/packages/sthrift/ui-sharethrift-route-signup/package.json
+++ b/packages/sthrift/ui-sharethrift-route-signup/package.json
@@ -29,6 +29,7 @@
 		"@cellix/arch-unit-tests": "workspace:*",
 		"@cellix/typescript-config": "workspace:*",
 		"@cellix/vitest-config": "workspace:*",
+		"@sthrift-verification/arch-unit-tests": "workspace:*",
 		"@storybook/react": "^10.1.11",
 		"@types/react": "^19.1.9",
 		"@types/react-dom": "^19.1.7",

--- a/packages/sthrift/ui-sharethrift-route-signup/src/arch-unit-tests/frontend-architecture.test.ts
+++ b/packages/sthrift/ui-sharethrift-route-signup/src/arch-unit-tests/frontend-architecture.test.ts
@@ -2,10 +2,20 @@ import {
 	describeFrontendArchitectureTests,
 	type FrontendArchitectureTestsConfig,
 } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeFrontendArchitectureTests as describeShareThriftFrontendArchitectureTests,
+	type FrontendArchitectureTestsConfig as ShareThriftFrontendArchitectureTestsConfig,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
-const config: FrontendArchitectureTestsConfig = {
+const cellixConfig: FrontendArchitectureTestsConfig = {
 	uiSourcePath: './src',
 	testName: 'UI ShareThrift Route Signup',
 };
 
-describeFrontendArchitectureTests(config);
+const shareThriftConfig: ShareThriftFrontendArchitectureTestsConfig = {
+	uiSourcePath: './src',
+	testName: 'UI ShareThrift Route Signup',
+};
+
+describeFrontendArchitectureTests(cellixConfig);
+describeShareThriftFrontendArchitectureTests(shareThriftConfig);

--- a/packages/sthrift/ui-sharethrift-route-signup/src/arch-unit-tests/naming-conventions.test.ts
+++ b/packages/sthrift/ui-sharethrift-route-signup/src/arch-unit-tests/naming-conventions.test.ts
@@ -1,3 +1,7 @@
 import { describeNamingConventionTests } from '@cellix/arch-unit-tests/frontend';
+import {
+	describeNamingConventionTests as describeShareThriftNamingConventionTests,
+} from '@sthrift-verification/arch-unit-tests/frontend';
 
 describeNamingConventionTests();
+describeShareThriftNamingConventionTests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,6 +1536,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1586,6 +1589,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1641,6 +1647,9 @@ importers:
       '@serenity-js/serenity-bdd':
         specifier: ^3.32.3
         version: 3.41.2
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1727,6 +1736,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       '@types/graphql-depth-limit':
         specifier: ^1.1.6
         version: 1.1.6
@@ -1779,6 +1791,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       rimraf:
         specifier: ^6.0.1
         version: 6.1.3
@@ -1847,6 +1862,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       '@storybook/react':
         specifier: ^10.1.11
         version: 10.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)
@@ -2011,6 +2029,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       '@storybook/react':
         specifier: ^10.1.11
         version: 10.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)
@@ -2121,6 +2142,9 @@ importers:
       '@cellix/vitest-config':
         specifier: workspace:*
         version: link:../../cellix/vitest-config
+      '@sthrift-verification/arch-unit-tests':
+        specifier: workspace:*
+        version: link:../../sthrift-verification/arch-unit-tests
       '@storybook/react':
         specifier: ^10.1.11
         version: 10.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.0(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         specifier: ^3.36.1
         version: 3.41.2
       '@sonar/scan':
-        specifier: ^4.3.0
+        specifier: 4.3.5
         version: 4.3.5
       '@types/node':
         specifier: ^24.10.7


### PR DESCRIPTION
## Summary by Sourcery

Introduce ShareThrift-specific architectural verification package and wire it into the SThrift services and UI packages alongside existing Cellix arch-unit tests.

New Features:
- Add @sthrift-verification/arch-unit-tests package exporting ShareThrift-specific checks and Vitest suites for application services, persistence, domain, GraphQL, frontend, and mongoose models.
- Enforce ShareThrift UI conventions for page stories, container placement, and container GraphQL/component pairing.
- Enforce naming and export conventions for persistence factories, application service factories, mongoose models, and domain authorization files.
- Add ShareThrift-specific GraphQL schema and resolver pairing checks to the arch-unit test suite.

Enhancements:
- Run both Cellix and ShareThrift arch-unit test suites across SThrift application-services, domain, persistence, GraphQL, data-sources-mongoose-models, and UI packages by configuring dual describe wrappers and configs.
- Tighten the tsconfig scope for the new arch-unit-tests package and expose structured subpath exports for consumption by other packages.

Documentation:
- Document how to use and extend the @sthrift-verification/arch-unit-tests package, including usage examples and CI guidance.